### PR TITLE
Attestation endblocker fixes

### DIFF
--- a/module/x/peggy/abci.go
+++ b/module/x/peggy/abci.go
@@ -1,6 +1,8 @@
 package peggy
 
 import (
+	"sort"
+
 	"github.com/althea-net/peggy/module/x/peggy/keeper"
 	"github.com/althea-net/peggy/module/x/peggy/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -176,19 +178,15 @@ func slashing(ctx sdk.Context, k keeper.Keeper) {
 // an attestation that has not passed the threshold
 func attestationTally(ctx sdk.Context, k keeper.Keeper) {
 	attmap := k.GetAttestationMapping(ctx)
-	for _, atts := range attmap {
-		for _, att := range atts {
-			// If it was already observed we don't need to do anything
-			if att.Observed {
-				continue
-			}
+	keys := make([]uint64, 0, len(attmap))
+	for k := range attmap {
+		keys = append(keys, k)
+	}
+	// the go standard library does not include a way to sort by uint64s...
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	for _, key := range keys {
+		for _, att := range attmap[key] {
 			k.TryAttestation(ctx, &att)
-			// If it was not Observed, break the loop, either the vote
-			// was not sufficient or the vote was sufficient and the claim
-			// is out of order.
-			if !att.Observed {
-				break
-			}
 		}
 	}
 }

--- a/orchestrator/orchestrator/src/ethereum_event_watcher.rs
+++ b/orchestrator/orchestrator/src/ethereum_event_watcher.rs
@@ -88,8 +88,9 @@ pub async fn check_for_events(
         }
 
         if !deposits.is_empty() || !withdraws.is_empty() {
-            let _res =
+            let res =
                 send_ethereum_claims(contact, our_private_key, deposits, withdraws, fee).await?;
+            trace!("Claims response {:?}", res);
             let new_event_nonce = get_last_event_nonce(grpc_client, our_cosmos_address).await?;
             // since we can't actually trust that the above txresponse is correct we have to check here
             // we may be able to trust the tx response post grpc
@@ -97,6 +98,8 @@ pub async fn check_for_events(
                 return Err(PeggyError::InvalidBridgeStateError(
                     "Claims did not process, trying again in a moment".to_string(),
                 ));
+            } else {
+                info!("Claims processed, new nonce {}", new_event_nonce);
             }
         }
         Ok(latest_block)

--- a/orchestrator/test_runner/src/transaction_stress_test.rs
+++ b/orchestrator/test_runner/src/transaction_stress_test.rs
@@ -107,8 +107,9 @@ pub async fn transaction_stress_test(
     }
 
     let start = Instant::now();
+    let mut good = true;
     while Instant::now() - start < TOTAL_TIMEOUT {
-        let mut good = true;
+        good = true;
         for keys in user_keys.iter() {
             let c_addr = keys.cosmos_address;
             let balances = contact.get_balances(c_addr).await.unwrap().result;
@@ -125,9 +126,18 @@ pub async fn transaction_stress_test(
             }
         }
         if good {
-            info!("All {} deposits bridged successfully!", user_keys.len());
+            info!(
+                "All {} deposits bridged successfully!",
+                user_keys.len() * erc20_addresses.len()
+            );
             break;
         }
         delay_for(Duration::from_secs(1)).await;
+    }
+    if !good {
+        panic!(
+            "Failed to perform all {} deposits!",
+            user_keys.len() * erc20_addresses.len()
+        );
     }
 }


### PR DESCRIPTION
This fixes an consensus error created by iterating over hashmaps, as well as the test that didn't fail properly preventing us from detecting this issue before it was merged in the first place. 