### PR TITLE
Transaction scale tests should produce batches as well. 

### DIFF
--- a/module/x/peggy/keeper/msg_server.go
+++ b/module/x/peggy/keeper/msg_server.go
@@ -137,7 +137,10 @@ func (k msgServer) SendToEth(c context.Context, msg *types.MsgSendToEth) (*types
 // RequestBatch handles MsgRequestBatch
 func (k msgServer) RequestBatch(c context.Context, msg *types.MsgRequestBatch) (*types.MsgRequestBatchResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
-	ec, _ := types.ERC20FromPeggyCoin(sdk.NewInt64Coin(msg.Denom, 0))
+	ec, err := types.ERC20FromPeggyCoin(sdk.NewInt64Coin(msg.Denom, 0))
+	if err != nil {
+		return nil, err
+	}
 	batchID, err := k.BuildOutgoingTXBatch(ctx, ec.Contract, OutgoingTxBatchSize)
 	if err != nil {
 		return nil, err

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -603,9 +603,9 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "contact"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e43b5d02476a702c085d5d4fc172a4b1a23414e30f4cca6813ef8208fb32f8"
+checksum = "325ab26c8ccf3135d4465829eb008b8ff41f40014fa612c64669f632fda74eae"
 dependencies = [
  "actix-web",
  "deep_space",

--- a/orchestrator/ethereum_peggy/src/lib.rs
+++ b/orchestrator/ethereum_peggy/src/lib.rs
@@ -1,5 +1,7 @@
 //! This crate contains various components and utilities for interacting with the Peggy Ethereum contract.
 
+use clarity::Uint256;
+
 #[macro_use]
 extern crate log;
 
@@ -8,3 +10,7 @@ pub mod send_to_cosmos;
 pub mod submit_batch;
 pub mod utils;
 pub mod valset_update;
+
+pub fn one_eth() -> Uint256 {
+    1000000000000000000u128.into()
+}

--- a/orchestrator/ethereum_peggy/src/utils.rs
+++ b/orchestrator/ethereum_peggy/src/utils.rs
@@ -178,3 +178,16 @@ pub async fn get_erc20_symbol(
     // deal with a deprecated feature (the symbol), which will be removed soon
     Ok(String::from_utf8(val_symbol).unwrap())
 }
+
+/// Just a helper struct to represent the cost of actions on Ethereum
+#[derive(Debug, Default, Clone)]
+pub struct GasCost {
+    pub gas: Uint256,
+    pub gas_price: Uint256,
+}
+
+impl GasCost {
+    pub fn get_total(&self) -> Uint256 {
+        self.gas.clone() * self.gas_price.clone()
+    }
+}

--- a/orchestrator/ethereum_peggy/src/valset_update.rs
+++ b/orchestrator/ethereum_peggy/src/valset_update.rs
@@ -1,11 +1,10 @@
-use crate::utils::get_valset_nonce;
-use clarity::Address as EthAddress;
+use crate::utils::{get_valset_nonce, GasCost};
 use clarity::PrivateKey as EthPrivateKey;
+use clarity::{Address as EthAddress, Uint256};
 use peggy_utils::error::PeggyError;
 use peggy_utils::types::*;
-use std::time::Duration;
-use web30::client::Web3;
-use web30::types::SendTxOption;
+use std::{cmp::min, time::Duration};
+use web30::{client::Web3, types::TransactionRequest};
 
 /// this function generates an appropriate Ethereum transaction
 /// to submit the provided validator set and signatures.
@@ -18,8 +17,6 @@ pub async fn send_eth_valset_update(
     peggy_contract_address: EthAddress,
     our_eth_key: EthPrivateKey,
 ) -> Result<(), PeggyError> {
-    let (old_addresses, old_powers) = old_valset.filter_empty_addresses();
-    let (new_addresses, new_powers) = new_valset.filter_empty_addresses();
     let old_nonce = old_valset.nonce;
     let new_nonce = new_valset.nonce;
     assert!(new_nonce > old_nonce);
@@ -28,6 +25,92 @@ pub async fn send_eth_valset_update(
         "Ordering signatures and submitting validator set {} -> {} update to Ethereum",
         old_nonce, new_nonce
     );
+    let before_nonce = get_valset_nonce(peggy_contract_address, eth_address, web3).await?;
+    if before_nonce != old_nonce {
+        info!(
+            "Someone else updated the valset to {}, exiting early",
+            before_nonce
+        );
+        return Ok(());
+    }
+
+    let payload = encode_valset_payload(new_valset, old_valset, confirms)?;
+
+    let tx = web3
+        .send_transaction(
+            peggy_contract_address,
+            payload,
+            0u32.into(),
+            eth_address,
+            our_eth_key,
+            vec![],
+        )
+        .await?;
+    info!("Sent valset update with txid {:#066x}", tx);
+
+    web3.wait_for_transaction(tx, timeout, None).await?;
+
+    let last_nonce = get_valset_nonce(peggy_contract_address, eth_address, web3).await?;
+    if last_nonce != new_nonce {
+        error!(
+            "Current nonce is {} expected to update to nonce {}",
+            last_nonce, new_nonce
+        );
+    } else {
+        info!(
+            "Successfully updated Valset with new Nonce {:?}",
+            last_nonce
+        );
+    }
+    Ok(())
+}
+
+/// Returns the cost in Eth of sending this valset update
+pub async fn estimate_valset_cost(
+    new_valset: &Valset,
+    old_valset: &Valset,
+    confirms: &[ValsetConfirmResponse],
+    web3: &Web3,
+    peggy_contract_address: EthAddress,
+    our_eth_key: EthPrivateKey,
+) -> Result<GasCost, PeggyError> {
+    let our_eth_address = our_eth_key.to_public_key().unwrap();
+    let our_balance = web3.eth_get_balance(our_eth_address).await?;
+    let our_nonce = web3.eth_get_transaction_count(our_eth_address).await?;
+    let gas_limit = min((u64::MAX - 1).into(), our_balance.clone());
+    let gas_price = web3.eth_gas_price().await?;
+    let zero: Uint256 = 0u8.into();
+    let val = web3
+        .eth_estimate_gas(TransactionRequest {
+            from: Some(our_eth_address),
+            to: peggy_contract_address,
+            nonce: Some(our_nonce.clone().into()),
+            gas_price: Some(gas_price.clone().into()),
+            gas: Some(gas_limit.into()),
+            value: Some(zero.into()),
+            data: Some(
+                encode_valset_payload(new_valset.clone(), old_valset.clone(), confirms)?.into(),
+            ),
+        })
+        .await?;
+
+    Ok(GasCost {
+        gas: val,
+        gas_price,
+    })
+}
+
+/// Encodes the payload bytes for the validator set update call, useful for
+/// estimating the cost of submitting a validator set
+fn encode_valset_payload(
+    new_valset: Valset,
+    old_valset: Valset,
+    confirms: &[ValsetConfirmResponse],
+) -> Result<Vec<u8>, PeggyError> {
+    let (old_addresses, old_powers) = old_valset.filter_empty_addresses();
+    let (new_addresses, new_powers) = new_valset.filter_empty_addresses();
+    let old_nonce = old_valset.nonce;
+    let new_nonce = new_valset.nonce;
 
     // we need to use the old valset here because our signatures need to match the current
     // members of the validator set in the contract.
@@ -62,45 +145,5 @@ pub async fn send_eth_valset_update(
     let payload = clarity::abi::encode_call("updateValset(address[],uint256[],uint256,address[],uint256[],uint256,uint8[],bytes32[],bytes32[])",
     tokens).unwrap();
 
-    let before_nonce = get_valset_nonce(peggy_contract_address, eth_address, web3).await?;
-    if before_nonce != old_nonce {
-        info!(
-            "Someone else updated the valset to {}, exiting early",
-            before_nonce
-        );
-        return Ok(());
-    }
-
-    let tx = web3
-        .send_transaction(
-            peggy_contract_address,
-            payload,
-            0u32.into(),
-            eth_address,
-            our_eth_key,
-            vec![SendTxOption::GasLimit(1_000_000u32.into())],
-        )
-        .await?;
-    info!("Sent valset update with txid {:#066x}", tx);
-
-    // TODO this segment of code works around the race condition for submitting valsets mostly
-    // by not caring if our own submission reverts and only checking if the valset has been updated
-    // period not if our update succeeded in particular. This will require some further consideration
-    // in the future as many independent relayers racing to update the same thing will hopefully
-    // be the common case.
-    web3.wait_for_transaction(tx, timeout, None).await?;
-
-    let last_nonce = get_valset_nonce(peggy_contract_address, eth_address, web3).await?;
-    if last_nonce != new_nonce {
-        error!(
-            "Current nonce is {} expected to update to nonce {}",
-            last_nonce, new_nonce
-        );
-    } else {
-        info!(
-            "Successfully updated Valset with new Nonce {:?}",
-            last_nonce
-        );
-    }
-    Ok(())
+    Ok(payload)
 }

--- a/orchestrator/orchestrator/src/main_loop.rs
+++ b/orchestrator/orchestrator/src/main_loop.rs
@@ -201,7 +201,12 @@ pub async fn eth_signer_main_loop(
         // sign the last unsigned batch, TODO check if we already have signed this
         match get_oldest_unsigned_transaction_batch(&mut grpc_client, our_cosmos_address).await {
             Ok(Some(last_unsigned_batch)) => {
-                info!("Sending batch confirm for {}", last_unsigned_batch.nonce);
+                info!(
+                    "Sending batch confirm for {}:{} with {} in fees",
+                    last_unsigned_batch.token_contract,
+                    last_unsigned_batch.nonce,
+                    last_unsigned_batch.total_fee.amount
+                );
                 let res = send_batch_confirm(
                     &contact,
                     ethereum_key,

--- a/orchestrator/relayer/src/batch_relaying.rs
+++ b/orchestrator/relayer/src/batch_relaying.rs
@@ -96,11 +96,11 @@ pub async fn relay_batches(
             }
             let cost = cost.unwrap();
             info!(
-                "We have detected latest batch {} but latest on Ethereum is {} This batch is estimated to cost {} wei / {:.4} ETH to submit",
+                "We have detected latest batch {} but latest on Ethereum is {} This batch is estimated to cost {} Gas / {:.4} ETH to submit",
                 latest_cosmos_batch_nonce,
                 latest_ethereum_batch,
-                cost.clone(),
-                downcast_to_u128(cost).unwrap() as f32
+                cost.gas_price.clone(),
+                downcast_to_u128(cost.get_total()).unwrap() as f32
                     / downcast_to_u128(one_eth()).unwrap() as f32
             );
 

--- a/orchestrator/relayer/src/valset_relaying.rs
+++ b/orchestrator/relayer/src/valset_relaying.rs
@@ -90,19 +90,6 @@ pub async fn relay_valsets(
                 / downcast_to_u128(one_eth()).unwrap() as f32
         );
 
-        // If the ENV var NO_GAS_OPT is not set at compile time then the resulting binary will not
-        // have gas optimizations. In this case if we exit early if gas optimizations are enabled
-        // (the default value)
-        if option_env!("NO_GAS_OPT").is_none() {
-            let diff = current_valset.power_diff(&latest_cosmos_valset);
-            // if the power difference is less than one percent, skip updating
-            // the validator set
-            if diff < 0.01 {
-                info!("Difference in power between valset {} and {} is less than 1% skipping update to save gas", current_valset.nonce, latest_cosmos_valset.nonce);
-                return;
-            }
-        }
-
         let _res = send_eth_valset_update(
             latest_cosmos_valset,
             current_valset,

--- a/orchestrator/test_runner/src/happy_path.rs
+++ b/orchestrator/test_runner/src/happy_path.rs
@@ -1,3 +1,5 @@
+use crate::get_fee;
+use crate::get_test_token_name;
 use crate::{
     utils::*, COSMOS_NODE_GRPC, MINER_ADDRESS, MINER_PRIVATE_KEY, STARTING_STAKE_PER_VALIDATOR,
     TOTAL_TIMEOUT,
@@ -31,9 +33,7 @@ pub async fn happy_path_test(
     contact: &Contact,
     keys: Vec<(CosmosPrivateKey, EthPrivateKey)>,
     peggy_address: EthAddress,
-    test_token_name: String,
     erc20_address: EthAddress,
-    fee: Coin,
     validator_out: bool,
 ) {
     let mut grpc_client = grpc_client;
@@ -57,7 +57,7 @@ pub async fn happy_path_test(
             contact.clone(),
             grpc_client,
             peggy_address,
-            test_token_name.clone(),
+            get_test_token_name(),
         ));
 
         // used to break out of the loop early to simulate one validator
@@ -123,7 +123,6 @@ pub async fn happy_path_test(
         1u64.into(),
         dest_cosmos_address,
         keys.clone(),
-        fee.clone(),
     )
     .await;
 
@@ -134,7 +133,6 @@ pub async fn happy_path_test(
         &web30,
         dest_eth_address,
         peggy_address,
-        fee,
         keys[0].0,
         dest_cosmos_private_key,
         erc20_address,
@@ -337,7 +335,6 @@ async fn test_batch(
     web30: &Web3,
     dest_eth_address: EthAddress,
     peggy_address: EthAddress,
-    fee: Coin,
     requester_cosmos_private_key: CosmosPrivateKey,
     dest_cosmos_private_key: CosmosPrivateKey,
     erc20_contract: EthAddress,
@@ -379,7 +376,7 @@ async fn test_batch(
     send_request_batch(
         requester_cosmos_private_key,
         token_name.clone(),
-        fee.clone(),
+        get_fee(),
         &contact,
     )
     .await
@@ -457,7 +454,6 @@ async fn submit_duplicate_erc20_send(
     amount: Uint256,
     receiver: CosmosAddress,
     keys: Vec<(CosmosPrivateKey, EthPrivateKey)>,
-    fee: Coin,
 ) {
     let start_coin = check_cosmos_balance("peggy", receiver, &contact)
         .await
@@ -478,7 +474,7 @@ async fn submit_duplicate_erc20_send(
 
     // iterate through all validators and try to send an event with duplicate nonce
     for (c_key, _) in keys.iter() {
-        let res = send_ethereum_claims(contact, *c_key, vec![event.clone()], vec![], fee.clone())
+        let res = send_ethereum_claims(contact, *c_key, vec![event.clone()], vec![], get_fee())
             .await
             .unwrap();
         trace!("Submitted duplicate sendToCosmos event: {:?}", res);

--- a/orchestrator/test_runner/src/main.rs
+++ b/orchestrator/test_runner/src/main.rs
@@ -10,8 +10,8 @@ extern crate lazy_static;
 
 use crate::bootstrapping::*;
 use crate::utils::*;
-use clarity::Address as EthAddress;
 use clarity::PrivateKey as EthPrivateKey;
+use clarity::{Address as EthAddress, Uint256};
 use contact::client::Contact;
 use cosmos_peggy::utils::wait_for_cosmos_online;
 use deep_space::coin::Coin;
@@ -68,6 +68,10 @@ pub fn get_fee() -> Coin {
 
 pub fn get_test_token_name() -> String {
     "footoken".to_string()
+}
+
+pub fn one_eth() -> Uint256 {
+    1000000000000000000u128.into()
 }
 
 #[actix_rt::main]
@@ -129,6 +133,7 @@ pub async fn main() {
             .await;
             return;
         } else if test_type == "BATCH_STRESS" {
+            let contact = Contact::new(COSMOS_NODE, TOTAL_TIMEOUT);
             transaction_stress_test(&web30, &contact, keys, peggy_address, erc20_addresses).await;
             return;
         } else if test_type == "VALSET_STRESS" {

--- a/orchestrator/test_runner/src/transaction_stress_test.rs
+++ b/orchestrator/test_runner/src/transaction_stress_test.rs
@@ -116,7 +116,7 @@ pub async fn transaction_stress_test(
             for token in erc20_addresses.iter() {
                 let mut found = false;
                 for balance in balances.iter() {
-                    if balance.denom.contains(&token.to_string()) {
+                    if balance.denom.contains(&token.to_string()) && balance.amount == one_eth() {
                         found = true;
                     }
                 }

--- a/orchestrator/test_runner/src/transaction_stress_test.rs
+++ b/orchestrator/test_runner/src/transaction_stress_test.rs
@@ -1,29 +1,45 @@
-use crate::{utils::*, COSMOS_NODE_GRPC, TOTAL_TIMEOUT};
+use crate::{get_fee, get_test_token_name, one_eth, utils::*, COSMOS_NODE_GRPC, TOTAL_TIMEOUT};
 use actix::{clock::delay_for, Arbiter};
+use clarity::Address as EthAddress;
 use clarity::PrivateKey as EthPrivateKey;
-use clarity::{Address as EthAddress, Uint256};
 use contact::client::Contact;
-use deep_space::address::Address as CosmosAddress;
+use cosmos_peggy::send::{send_request_batch, send_to_eth};
 use deep_space::private_key::PrivateKey as CosmosPrivateKey;
-use ethereum_peggy::send_to_cosmos::send_to_cosmos;
+use deep_space::{address::Address as CosmosAddress, coin::Coin};
+use ethereum_peggy::{send_to_cosmos::send_to_cosmos, utils::get_tx_batch_nonce};
 use futures::future::join_all;
 use orchestrator::main_loop::orchestrator_main_loop;
 use peggy_proto::peggy::query_client::QueryClient as PeggyQueryClient;
 use rand::Rng;
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashSet,
+    time::{Duration, Instant},
+};
 use web30::client::Web3;
 
 const TIMEOUT: Duration = Duration::from_secs(120);
 
-pub fn one_eth() -> Uint256 {
-    1000000000000000000u128.into()
-}
+/// The number of users we will be simulating for this test, each user
+/// will get one token from each token type in erc20_addresses and send it
+/// across the bridge to Cosmos as a deposit and then send it back to a different
+/// Ethereum address in a transaction batch
+/// So the total number of
+/// Ethereum sends = (2 * NUM_USERS)
+/// ERC20 sends = (erc20_addresses.len() * NUM_USERS)
+/// Peggy Deposits = (erc20_addresses.len() * NUM_USERS)
+/// Batches executed = erc20_addresses.len() * (NUM_USERS / 100)
+const NUM_USERS: usize = 100;
 
 pub struct BridgeUserKey {
+    // the starting addresses that get Eth balances to send across the bridge
     pub eth_address: EthAddress,
     pub eth_key: EthPrivateKey,
+    // the cosmos addresses that get the funds and send them on to the dest eth addresses
     pub cosmos_address: CosmosAddress,
     pub cosmos_key: CosmosPrivateKey,
+    // the location tokens are sent back to on Ethereum
+    pub eth_dest_address: EthAddress,
+    pub eth_dest_key: EthPrivateKey,
 }
 
 /// Perform a stress test by sending thousands of
@@ -34,7 +50,6 @@ pub async fn transaction_stress_test(
     contact: &Contact,
     keys: Vec<(CosmosPrivateKey, EthPrivateKey)>,
     peggy_address: EthAddress,
-    test_token_name: String,
     erc20_addresses: Vec<EthAddress>,
 ) {
     // start orchestrators
@@ -50,32 +65,50 @@ pub async fn transaction_stress_test(
             contact.clone(),
             grpc_client,
             peggy_address,
-            test_token_name.clone(),
+            get_test_token_name(),
         ));
     }
 
     // Generate 100 user keys to send ETH and multiple types of tokens
     let mut user_keys = Vec::new();
-    for _ in 0..100 {
+    for _ in 0..NUM_USERS {
         let mut rng = rand::thread_rng();
         let secret: [u8; 32] = rng.gen();
-        let cosmos_key = CosmosPrivateKey::from_secret(&secret);
-        let cosmos_address = cosmos_key.to_public_key().unwrap().to_address();
+        // the starting location of the funds
         let eth_key = EthPrivateKey::from_slice(&secret).unwrap();
         let eth_address = eth_key.to_public_key().unwrap();
+        // the destination on cosmos that sends along to the final ethereum destination
+        let cosmos_key = CosmosPrivateKey::from_secret(&secret);
+        let cosmos_address = cosmos_key.to_public_key().unwrap().to_address();
+        let mut rng = rand::thread_rng();
+        let secret: [u8; 32] = rng.gen();
+        // the final destination of the tokens back on Ethereum
+        let eth_dest_key = EthPrivateKey::from_slice(&secret).unwrap();
+        let eth_dest_address = eth_key.to_public_key().unwrap();
         user_keys.push(BridgeUserKey {
             eth_address,
             eth_key,
             cosmos_address,
             cosmos_key,
+            eth_dest_key,
+            eth_dest_address,
         })
     }
-    let eth_destinations: Vec<EthAddress> = user_keys.iter().map(|i| i.eth_address).collect();
+    // the sending eth addresses need Ethereum to send ERC20 tokens to the bridge
+    let sending_eth_addresses: Vec<EthAddress> = user_keys.iter().map(|i| i.eth_address).collect();
+    // the destination eth addresses need Ethereum to perform a contract call and get their erc20 balances
+    let dest_eth_addresses: Vec<EthAddress> =
+        user_keys.iter().map(|i| i.eth_dest_address).collect();
+    let mut eth_destinations = Vec::new();
+    eth_destinations.extend(sending_eth_addresses.clone());
+    eth_destinations.extend(dest_eth_addresses);
     send_eth_bulk(one_eth(), &eth_destinations, web30).await;
-    info!("Sent {} addresses 1 ETH", user_keys.len());
+    info!("Sent {} addresses 1 ETH", NUM_USERS);
+
+    // now we need to send all the sending eth addresses erc20's to send
     for token in erc20_addresses.iter() {
-        send_erc20_bulk(one_eth(), *token, &eth_destinations, web30).await;
-        info!("Sent {} addresses 1 {}", user_keys.len(), token);
+        send_erc20_bulk(one_eth(), *token, &sending_eth_addresses, web30).await;
+        info!("Sent {} addresses 1 {}", NUM_USERS, token);
     }
     for token in erc20_addresses.iter() {
         let mut sends = Vec::new();
@@ -103,7 +136,10 @@ pub async fn transaction_stress_test(
             let result = result.unwrap();
             result.block_number.unwrap();
         }
-        info!("Locked 1 {} from {} into Peggy", token, user_keys.len());
+        info!(
+            "Locked 1 {} from {} into the Gravity Ethereum Contract",
+            token, NUM_USERS
+        );
     }
 
     let start = Instant::now();
@@ -127,17 +163,109 @@ pub async fn transaction_stress_test(
         }
         if good {
             info!(
-                "All {} deposits bridged successfully!",
+                "All {} deposits bridged to Cosmos successfully!",
                 user_keys.len() * erc20_addresses.len()
             );
             break;
         }
-        delay_for(Duration::from_secs(1)).await;
+        delay_for(Duration::from_secs(5)).await;
     }
     if !good {
         panic!(
-            "Failed to perform all {} deposits!",
+            "Failed to perform all {} deposits to Cosmos!",
             user_keys.len() * erc20_addresses.len()
         );
+    }
+
+    let send_amount = one_eth() - 500u16.into();
+
+    let mut denoms = HashSet::new();
+    for token in erc20_addresses.iter() {
+        let mut futs = Vec::new();
+        for keys in user_keys.iter() {
+            let c_addr = keys.cosmos_address;
+            let c_key = keys.cosmos_key;
+            let e_dest_addr = keys.eth_dest_address;
+            let balances = contact.get_balances(c_addr).await.unwrap().result;
+            // this way I don't have to hardcode a denom and we can change the way denoms are formed
+            // without changing this test.
+            let mut send_coin = None;
+            for balance in balances {
+                if balance.denom.contains(&token.to_string()) {
+                    send_coin = Some(balance.clone());
+                    denoms.insert(balance.denom);
+                }
+            }
+            let mut send_coin = send_coin.unwrap();
+            send_coin.amount = send_amount.clone();
+            let send_fee = Coin {
+                denom: send_coin.denom.clone(),
+                amount: 1u8.into(),
+            };
+            let res = send_to_eth(c_key, e_dest_addr, send_coin, send_fee, &contact);
+            futs.push(res);
+        }
+        let results = join_all(futs).await;
+        for result in results {
+            let result = result.unwrap();
+            trace!("SendToEth result {:?}", result);
+        }
+        info!(
+            "Successfully placed {} {} into the tx pool",
+            NUM_USERS, token
+        );
+    }
+
+    for denom in denoms {
+        info!("Requesting batch for {}", denom);
+        let res = send_request_batch(keys[0].0, denom, get_fee(), &contact)
+            .await
+            .unwrap();
+        info!("batch request response is {:?}", res);
+    }
+
+    let start = Instant::now();
+    let mut good = true;
+    while Instant::now() - start < TOTAL_TIMEOUT {
+        good = true;
+        for keys in user_keys.iter() {
+            let e_dest_addr = keys.eth_dest_address;
+            for token in erc20_addresses.iter() {
+                let bal = web30.get_erc20_balance(*token, e_dest_addr).await.unwrap();
+                if bal != send_amount.clone() {
+                    good = false;
+                }
+            }
+        }
+        if good {
+            info!(
+                "All {} withdraws to Ethereum bridged successfully!",
+                NUM_USERS * erc20_addresses.len()
+            );
+            break;
+        }
+        delay_for(Duration::from_secs(5)).await;
+    }
+    if !good {
+        panic!(
+            "Failed to perform all {} withdraws to Ethereum!",
+            NUM_USERS * erc20_addresses.len()
+        );
+    }
+
+    // we should find a batch nonce greater than zero since all the batches
+    // executed
+    for token in erc20_addresses {
+        assert!(
+            get_tx_batch_nonce(
+                peggy_address,
+                token,
+                keys[0].1.to_public_key().unwrap(),
+                web30
+            )
+            .await
+            .unwrap()
+                > 0
+        )
     }
 }

--- a/orchestrator/test_runner/src/utils.rs
+++ b/orchestrator/test_runner/src/utils.rs
@@ -7,8 +7,8 @@ use deep_space::private_key::PrivateKey as CosmosPrivateKey;
 use futures::future::join_all;
 use web30::{client::Web3, types::SendTxOption};
 
-use crate::MINER_PRIVATE_KEY;
 use crate::TOTAL_TIMEOUT;
+use crate::{one_eth, MINER_PRIVATE_KEY};
 use crate::{MINER_ADDRESS, OPERATION_TIMEOUT};
 
 /// This overly complex function primarily exists to parallelize the sending of Eth to the
@@ -21,8 +21,8 @@ use crate::{MINER_ADDRESS, OPERATION_TIMEOUT};
 pub async fn send_eth_to_orchestrators(keys: &[(CosmosPrivateKey, EthPrivateKey)], web30: &Web3) {
     let balance = web30.eth_get_balance(*MINER_ADDRESS).await.unwrap();
     info!(
-        "Sending orchestrators 1 eth to pay for fees miner has {} ETH",
-        balance / 1_000_000_000_000_000_000u128.into()
+        "Sending orchestrators 100 eth to pay for fees miner has {} ETH",
+        balance / one_eth()
     );
     let mut eth_addresses = Vec::new();
     for (_, e_key) in keys {
@@ -40,7 +40,7 @@ pub async fn send_eth_to_orchestrators(keys: &[(CosmosPrivateKey, EthPrivateKey)
             nonce: nonce.clone(),
             gas_price: 1_000_000_000u64.into(),
             gas_limit: 24000u64.into(),
-            value: 1_000_000_000_000_000_000u128.into(),
+            value: one_eth() * 100u16.into(),
             data: Vec::new(),
             signature: None,
         };

--- a/orchestrator/test_runner/src/valset_stress.rs
+++ b/orchestrator/test_runner/src/valset_stress.rs
@@ -1,4 +1,4 @@
-use crate::{happy_path::test_valset_update, COSMOS_NODE_GRPC};
+use crate::{get_test_token_name, happy_path::test_valset_update, COSMOS_NODE_GRPC};
 use actix::Arbiter;
 use clarity::Address as EthAddress;
 use clarity::PrivateKey as EthPrivateKey;
@@ -14,7 +14,6 @@ pub async fn validator_set_stress_test(
     contact: &Contact,
     keys: Vec<(CosmosPrivateKey, EthPrivateKey)>,
     peggy_address: EthAddress,
-    test_token_name: String,
 ) {
     // start orchestrators
     for (c_key, e_key) in keys.iter() {
@@ -29,7 +28,7 @@ pub async fn validator_set_stress_test(
             contact.clone(),
             grpc_client,
             peggy_address,
-            test_token_name.clone(),
+            get_test_token_name(),
         ));
     }
 

--- a/tests/assets/ETHGenesis.json
+++ b/tests/assets/ETHGenesis.json
@@ -10,7 +10,7 @@
     "petersburgBlock": 0
   },
   "difficulty": "0x400",
-  "gasLimit": "0x2100000",
+  "gasLimit": "0xB71B00",
   "alloc": {
     "0xBf660843528035a5A4921534E156a27e64B231fE": {
       "balance": "0x1337000000000000000000"

--- a/tests/container-scripts/integration-tests.sh
+++ b/tests/container-scripts/integration-tests.sh
@@ -16,4 +16,4 @@ killall -9 test-runner
 set -e
 
 pushd /peggy/orchestrator/test_runner
-RUST_BACKTRACE=full TEST_TYPE=$TEST_TYPE NO_GAS_OPT=1 RUST_LOG=INFO PATH=$PATH:$HOME/.cargo/bin cargo run --release --bin test-runner
+RUST_BACKTRACE=full TEST_TYPE=$TEST_TYPE RUST_LOG=INFO PATH=$PATH:$HOME/.cargo/bin cargo run --release --bin test-runner


### PR DESCRIPTION
This test expands the tx stress test to live up to it's name
BATCH_STRESS and actually send batches back to Ethereum.

There are a number of challenges to this, mostly that Cosmos is very
slow about including transactions in 'block' mode although this may be
the fault of our own aggressive retry.