### PR TITLE
Fix unclear attestation nonce check

### DIFF
--- a/module/x/peggy/abci.go
+++ b/module/x/peggy/abci.go
@@ -189,23 +189,28 @@ func attestationTally(ctx sdk.Context, k keeper.Keeper) {
 	// This iterates over all keys (event nonces) in the attestation mapping. Each value contains
 	// a slice with one or more attestations at that event nonce. There can be multiple attestations
 	// at one event nonce when validators disagree about what event happened at that nonce.
-	for _, key := range keys {
+	for _, nonce := range keys {
 		// This iterates over all attestations at a particular event nonce.
 		// They are ordered by when the first attestation at the event nonce was received.
 		// This order is not important.
-		for _, att := range attmap[key] {
+		for _, att := range attmap[nonce] {
 			// We check if the event nonce is exactly 1 higher than the last attestation that was
 			// observed. If it is not, we just move on to the next nonce. This will skip over all
-			// attestations that have already been observed. Once an attestation at a given event
-			// nonce has enough votes and becomes observed, every other attestation at that nonce
-			// will be skipped, since the lastObservedEventNonce will be incremented.
+			// attestations that have already been observed.
 			//
-			// Then we go to the next event nonce in the attestation mapping, if there is one.
+			// Once we hit an event nonce that is one higher than the last observed event, we stop
+			// skipping over this conditional and start calling tryAttestation (counting votes)
+			// Once an attestation at a given event nonce has enough votes and becomes observed,
+			// every other attestation at that nonce will be skipped, since the lastObservedEventNonce
+			// will be incremented.
+			//
+			// Then we go to the next event nonce in the attestation mapping, if there is one. This
+			// nonce will once again be one higher than the lastObservedEventNonce.
 			// If there is an attestation at this event nonce which has enough votes to be observed,
 			// we skip the other attestations and move on to the next nonce again.
 			// If no attestation becomes observed, when we get to the next nonce, every attestation in
 			// it will be skipped. The same will happen for every nonce after that.
-			if key == uint64(k.GetLastObservedEventNonce(ctx))+1 {
+			if nonce == uint64(k.GetLastObservedEventNonce(ctx))+1 {
 				k.TryAttestation(ctx, &att)
 			}
 		}

--- a/module/x/peggy/abci.go
+++ b/module/x/peggy/abci.go
@@ -178,15 +178,36 @@ func slashing(ctx sdk.Context, k keeper.Keeper) {
 // an attestation that has not passed the threshold
 func attestationTally(ctx sdk.Context, k keeper.Keeper) {
 	attmap := k.GetAttestationMapping(ctx)
+	// We make a slice with all the event nonces that are in the attestation mapping
 	keys := make([]uint64, 0, len(attmap))
 	for k := range attmap {
 		keys = append(keys, k)
 	}
-	// the go standard library does not include a way to sort by uint64s...
+	// Then we sort it
 	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
+	// This iterates over all keys (event nonces) in the attestation mapping. Each value contains
+	// a slice with one or more attestations at that event nonce. There can be multiple attestations
+	// at one event nonce when validators disagree about what event happened at that nonce.
 	for _, key := range keys {
+		// This iterates over all attestations at a particular event nonce.
+		// They are ordered by when the first attestation at the event nonce was received.
+		// This order is not important.
 		for _, att := range attmap[key] {
-			k.TryAttestation(ctx, &att)
+			// We check if the event nonce is exactly 1 higher than the last attestation that was
+			// observed. If it is not, we just move on to the next nonce. This will skip over all
+			// attestations that have already been observed. Once an attestation at a given event
+			// nonce has enough votes and becomes observed, every other attestation at that nonce
+			// will be skipped, since the lastObservedEventNonce will be incremented.
+			//
+			// Then we go to the next event nonce in the attestation mapping, if there is one.
+			// If there is an attestation at this event nonce which has enough votes to be observed,
+			// we skip the other attestations and move on to the next nonce again.
+			// If no attestation becomes observed, when we get to the next nonce, every attestation in
+			// it will be skipped. The same will happen for every nonce after that.
+			if key == uint64(k.GetLastObservedEventNonce(ctx))+1 {
+				k.TryAttestation(ctx, &att)
+			}
 		}
 	}
 }

--- a/module/x/peggy/keeper/attestation.go
+++ b/module/x/peggy/keeper/attestation.go
@@ -52,7 +52,6 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation) {
 	if err != nil {
 		panic("could not cast to claim")
 	}
-
 	// If the attestation has not yet been Observed, sum up the votes and see if it is ready to apply to the state.
 	// This conditional stops the attestation from accidentally being applied twice.
 	if !att.Observed {
@@ -71,14 +70,16 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation) {
 			attestationPower = attestationPower.Add(sdk.NewInt(validatorPower))
 			// If the power of all the validators that have voted on the attestation is higher or equal to the threshold,
 			// process the attestation, set Observed to true, and break
-			lastEventNonce := k.GetLastObservedEventNonce(ctx)
-			if attestationPower.GTE(requiredPower) && claim.GetEventNonce() == uint64(lastEventNonce)+1 {
+			if attestationPower.GTE(requiredPower) {
 				k.processAttestation(ctx, att, claim)
 				att.Observed = true
 				k.emitObservedEvent(ctx, att, claim)
 				break
 			}
 		}
+	} else {
+		// We panic here because this should never happen
+		panic("attempting to process observed attestation")
 	}
 }
 


### PR DESCRIPTION
This clarifies the role of `LastObservedEventNonce` in ordering observed attestations correctly. 

I moved a check on `LastObservedEventNonce` out of some unrelated logic and into the main `attestationTally` loop. This makes it easier to understand it's role in the system. I also added some comments, like this one: 

> 
> We check if the event nonce is exactly 1 higher than LastObservedEventNonce. If it is not, we just move on to the next attestation at that nonce, and then to the next nonce. 
> 
> This loop and check logic does several different things:
> 
> - First, will skip over all attestations that have already been observed. 
> - Once it hits an event nonce that is one higher than the last observed event, it stops skipping over the conditional and starts calling TryAttestation (counting votes) 
> - Once an attestation at a given event nonce has enough votes and becomes observed (this is what TryAttestation tries to do), every other attestation at that nonce will be skipped, since LastObservedEventNonce will be incremented. 
> - The loop then it goes to the next event nonce in the attestation mapping, if there is one. This nonce will once again be one higher than the lastObservedEventNonce.
> - If no attestation at that nonce becomes Observed, when we get to the next nonce, every attestation in it will be skipped. The same will happen for every nonce after that.
> 