### PR TITLE
add CmdSetOrchestratorAddress  and CmdSendToEth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ tests/test-runner/Cargo.lock
 tests/dockerfile/peggy.tar.gz
 solidity/dist
 
+# IDE files
+.idea/
+
 #Hardhat files
 cache
 artifacts

--- a/module/x/peggy/client/cli/tx.go
+++ b/module/x/peggy/client/cli/tx.go
@@ -174,8 +174,8 @@ func CmdSetOrchestratorAddress() *cobra.Command {
 
 			msg := types.MsgSetOrchestratorAddress{
 				Validator:    validatorAddr.String(),
-				Orchestrator: args[1],
-				EthAddress:   args[2],
+				Orchestrator: args[0],
+				EthAddress:   args[1],
 			}
 			if err := msg.ValidateBasic(); err != nil {
 				return err

--- a/module/x/peggy/client/cli/tx.go
+++ b/module/x/peggy/client/cli/tx.go
@@ -96,7 +96,7 @@ func CmdSendToEth() *cobra.Command {
 	return &cobra.Command{
 		Use:   "send-to-eth [eth-dest] [amount] [bridge-fee]",
 		Short: "Adds a new entry to the transaction pool to withdraw an amount from the Ethereum bridge contract",
-		Args:  cobra.ExactArgs(4),
+		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {


### PR DESCRIPTION
https://github.com/althea-net/cosmos-gravity-bridge/issues/193
>  Validators need to be able to send MsgDelegateKeys from the module command line. The current Rust system will not allow validators with keys in ledgers or other HW wallets to register

> Users should be able to send MsgSendToEth and MsgSendToCosmos from the module command line. This involves submitting Ethereum transactions

I don't think sending `MsgSendToCosmos` from x/peggy module CLI makes sense. We could easily add this inside of the peggo orchestrator binary instead @xlab @jackzampolin 