### PR TITLE
Slashing without pruning valset

### DIFF
--- a/module/x/peggy/abci.go
+++ b/module/x/peggy/abci.go
@@ -20,8 +20,8 @@ func slashing(ctx sdk.Context, k keeper.Keeper) {
 	params := k.GetParams(ctx)
 	currentBondedSet := k.StakingKeeper.GetBondedValidatorsByPower(ctx)
 
-	maxHeight := ctx.BlockHeight() - int64(params.SignedValsetsWindow) + 1
-	unslashedValsets := k.GetUnSlashedValsets(ctx, uint64(maxHeight))
+	maxHeight := uint64(ctx.BlockHeight()) - params.SignedValsetsWindow + 1
+	unslashedValsets := k.GetUnSlashedValsets(ctx, maxHeight)
 
 	// valsets are sorted by nonce in ASC order
 	for _, vs := range unslashedValsets {

--- a/module/x/peggy/abci.go
+++ b/module/x/peggy/abci.go
@@ -20,9 +20,10 @@ func slashing(ctx sdk.Context, k keeper.Keeper) {
 	params := k.GetParams(ctx)
 	currentBondedSet := k.StakingKeeper.GetBondedValidatorsByPower(ctx)
 
-	// valsets are sorted by nonce in ASC order
-	unslashedValsets := k.GetUnSlashedValsets(ctx)
+	maxHeight := ctx.BlockHeight() - int64(params.SignedValsetsWindow) + 1
+	unslashedValsets := k.GetUnSlashedValsets(ctx, uint64(maxHeight))
 
+	// valsets are sorted by nonce in ASC order
 	for _, vs := range unslashedValsets {
 		signedWithinWindow := uint64(ctx.BlockHeight()) > params.SignedValsetsWindow && uint64(ctx.BlockHeight())-params.SignedValsetsWindow > vs.Height
 		if !signedWithinWindow {

--- a/module/x/peggy/keeper/keeper.go
+++ b/module/x/peggy/keeper/keeper.go
@@ -183,7 +183,9 @@ func (k Keeper) GetLastSlashedValsetNonce(ctx sdk.Context) uint64 {
 func (k Keeper) GetUnSlashedValsets(ctx sdk.Context, maxHeight uint64) (out []*types.Valset) {
 	lastSlashedValsetNonce := k.GetLastSlashedValsetNonce(ctx)
 	k.IterateValsetBySlashedValsetNonce(ctx, lastSlashedValsetNonce, maxHeight, func(_ []byte, valset *types.Valset) bool {
-		out = append(out, valset)
+		if valset.Nonce > lastSlashedValsetNonce {
+			out = append(out, valset)
+		}
 		return false
 	})
 	return

--- a/module/x/peggy/keeper/keeper.go
+++ b/module/x/peggy/keeper/keeper.go
@@ -180,10 +180,9 @@ func (k Keeper) GetLastSlashedValsetNonce(ctx sdk.Context) uint64 {
 }
 
 // GetUnSlashedValsets returns all the unslashed validator sets in state
-func (k Keeper) GetUnSlashedValsets(ctx sdk.Context) (out []*types.Valset) {
+func (k Keeper) GetUnSlashedValsets(ctx sdk.Context, maxHeight uint64) (out []*types.Valset) {
 	lastSlashedValsetNonce := k.GetLastSlashedValsetNonce(ctx)
-	latestValsetNonce := k.GetLatestValsetNonce(ctx)
-	k.IterateValsetBySlashedValsetNonce(ctx, lastSlashedValsetNonce, latestValsetNonce, func(_ []byte, valset *types.Valset) bool {
+	k.IterateValsetBySlashedValsetNonce(ctx, lastSlashedValsetNonce, maxHeight, func(_ []byte, valset *types.Valset) bool {
 		out = append(out, valset)
 		return false
 	})
@@ -191,9 +190,9 @@ func (k Keeper) GetUnSlashedValsets(ctx sdk.Context) (out []*types.Valset) {
 }
 
 // IterateValsetBySlashedValsetNonce iterates through all valset by last slashed valset nonce in ASC order
-func (k Keeper) IterateValsetBySlashedValsetNonce(ctx sdk.Context, lastSlashedValsetNonce uint64, latestValsetNonce uint64, cb func([]byte, *types.Valset) bool) {
+func (k Keeper) IterateValsetBySlashedValsetNonce(ctx sdk.Context, lastSlashedValsetNonce uint64, maxHeight uint64, cb func([]byte, *types.Valset) bool) {
 	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), types.ValsetRequestKey)
-	iter := prefixStore.Iterator(types.UInt64Bytes(lastSlashedValsetNonce), types.UInt64Bytes(latestValsetNonce))
+	iter := prefixStore.Iterator(types.UInt64Bytes(lastSlashedValsetNonce), types.UInt64Bytes(maxHeight))
 	defer iter.Close()
 
 	for ; iter.Valid(); iter.Next() {

--- a/module/x/peggy/types/key.go
+++ b/module/x/peggy/types/key.go
@@ -96,6 +96,12 @@ var (
 
 	// ERC20ToDenomKey prefixes the index of Cosmos originated assets ERC20s to denoms
 	ERC20ToDenomKey = []byte{0xf4}
+
+	// LastSlashedValsetNonce indexes the latest slashed valset nonce
+	LastSlashedValsetNonce = []byte{0xf5}
+
+	// LatestValsetNonce indexes the latest valset nonce
+	LatestValsetNonce = []byte{0xf6}
 )
 
 // GetOrchestratorAddressKey returns the following key format


### PR DESCRIPTION
Changes

- [x] Persist Latest valset nonce. 
- [x] Persist last slashed valset nonce.
- [x] Added Iterator which fetches valsets between `LastSlashedValsetNonce` and `LatestValsetNonce`.
- [x] Removed Pruning logic.
- [x] New `ValsetRequest` is created only if PowerDiff > 5%. 

Advantages

- Availability of valsets for relayer to publish(to Peggy contract on L1) even after signing window.
- Stop creating valsets for each signing window.
- Reduced iterations in valset slashing logic.
