### PR TITLE
Contract cleanup

### DIFF
--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -493,13 +493,13 @@ contract Peggy {
 			);
 		}
 
+		// Make call to logic contract
+		bytes memory returnData = Address.functionCall(_args.logicContractAddress, _args.payload);
+		
 		// Send fees to msg.sender
 		for (uint256 i = 0; i < _args.feeAmounts.length; i++) {
 			IERC20(_args.feeTokenContracts[i]).safeTransfer(msg.sender, _args.feeAmounts[i]);
 		}
-
-		// Make call to logic contract
-		bytes memory returnData = Address.functionCall(_args.logicContractAddress, _args.payload);
 
 		// LOGS scoped to reduce stack depth
 		{

--- a/solidity/contracts/ReentrantERC20.sol
+++ b/solidity/contracts/ReentrantERC20.sol
@@ -1,0 +1,48 @@
+pragma solidity ^0.6.6;
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "./Peggy.sol";
+
+pragma experimental ABIEncoderV2;
+
+// Reentrant evil erc20
+contract ReentrantERC20 {
+    address state_peggyAddress;
+
+    constructor(address _peggyAddress) public {
+        state_peggyAddress = _peggyAddress;
+    }
+
+    function transfer(address recipient, uint256 amount) public returns (bool) {
+        // _currentValidators, _currentPowers, _currentValsetNonce, _v, _r, _s, _args);(
+        address[] memory addresses = new address[](0);
+        bytes32[] memory bytes32s = new bytes32[](0);
+        uint256[] memory uint256s = new uint256[](0);
+        bytes memory bytess = new bytes(0);
+        uint256 zero = 0;
+        LogicCallArgs memory args;
+
+        {
+            args = LogicCallArgs(
+                uint256s,
+                addresses,
+                uint256s,
+                addresses,
+                address(0),
+                bytess,
+                zero,
+                bytes32(0),
+                zero
+            );
+        }
+        
+        Peggy(state_peggyAddress).submitLogicCall(
+            addresses, 
+            uint256s, 
+            zero, 
+            new uint8[](0), 
+            bytes32s, 
+            bytes32s,
+            args
+        );
+    }
+}

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -831,5 +831,8 @@ module.exports = {
   },
   gasReporter: {
     enabled: true
+  },
+  mocha: {
+    timeout: 200000
   }
 };

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hardhat-test",
+  "name": "gravity-contracts",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -11,7 +11,7 @@
     "evm_fork": "npx hardhat node --fork https://eth-mainnet.alchemyapi.io/v2/${ALCHEMY_ID} --fork-block-number 11780000",
     "test_fork": "npx hardhat test --network localhost ./tests_mainnet_fork/*.ts"
   },
-  "author": "",
+  "author": "Jehan Tremback",
   "license": "None",
   "devDependencies": {
     "@commitlint/cli": "^9.1.2",

--- a/solidity/test/submitBatch-vs-logicCall.ts
+++ b/solidity/test/submitBatch-vs-logicCall.ts
@@ -8,316 +8,348 @@ import {
   getSignerAddresses,
   makeCheckpoint,
   signHash,
-  examplePowers
+  examplePowers,
 } from "../test-utils/pure";
 import { Signer } from "ethers";
 import { Peggy } from "../typechain/Peggy";
 import { TestERC20A } from "../typechain/TestERC20A";
+import { ReentrantERC20 } from "../typechain/ReentrantERC20";
 
 chai.use(solidity);
 const { expect } = chai;
 
 async function prepareTxBatch(batchSize: number, signers: Signer[]) {
-    const numTxs = batchSize;
-    const destinations = new Array(numTxs);
-    const fees = new Array(numTxs);
-    const amounts = new Array(numTxs);
-    for (let i = 0; i < numTxs; i++) {
-      fees[i] = 1;
-      amounts[i] = 1;
-      destinations[i] = await signers[i + 5].getAddress();
-    }
+  const numTxs = batchSize;
+  const destinations = new Array(numTxs);
+  const fees = new Array(numTxs);
+  const amounts = new Array(numTxs);
+  for (let i = 0; i < numTxs; i++) {
+    fees[i] = 1;
+    amounts[i] = 1;
+    destinations[i] = await signers[i + 5].getAddress();
+  }
 
-    return {
-      numTxs,
-      destinations,
-      fees,
-      amounts
-    }
+  return {
+    numTxs,
+    destinations,
+    fees,
+    amounts,
+  };
 }
 
-async function sendToCosmos(peggy: Peggy, testERC20: TestERC20A, numCoins: number) {
-    // Transfer out to Cosmos, locking coins
-    // =====================================
-    await testERC20.functions.approve(peggy.address, numCoins);
-    await peggy.functions.sendToCosmos(
-      testERC20.address,
-      ethers.utils.formatBytes32String("myCosmosAddress"),
-      numCoins
-    );
+async function sendToCosmos(
+  peggy: Peggy,
+  testERC20: TestERC20A,
+  numCoins: number
+) {
+  // Transfer out to Cosmos, locking coins
+  // =====================================
+  await testERC20.functions.approve(peggy.address, numCoins);
+  await peggy.functions.sendToCosmos(
+    testERC20.address,
+    ethers.utils.formatBytes32String("myCosmosAddress"),
+    numCoins
+  );
 }
 
 async function prep() {
-    // Deploy contracts
-    // ================
+  // Deploy contracts
+  // ================
 
-    const signers = await ethers.getSigners();
-    const peggyId = ethers.utils.formatBytes32String("foo");
+  const signers = await ethers.getSigners();
+  const peggyId = ethers.utils.formatBytes32String("foo");
 
-    let powers = examplePowers();
-    let validators = signers.slice(0, powers.length);
+  let powers = examplePowers();
+  let validators = signers.slice(0, powers.length);
 
-    const powerThreshold = 6666;
+  const powerThreshold = 6666;
 
-    const {
-      peggy,
-      testERC20,
-    } = await deployContracts(peggyId, validators, powers, powerThreshold);
+  const { peggy, testERC20 } = await deployContracts(
+    peggyId,
+    validators,
+    powers,
+    powerThreshold
+  );
 
-    return {
-      signers,
-      peggyId,
-      powers,
-      validators,
-      peggy,
-      testERC20,
-    }
+  const ReentrantERC20Contract = await ethers.getContractFactory(
+    "ReentrantERC20"
+  );
+  const reentrantERC20 = (await ReentrantERC20Contract.deploy(
+    peggy.address
+  )) as ReentrantERC20;
+
+  return {
+    signers,
+    peggyId,
+    powers,
+    validators,
+    peggy,
+    testERC20,
+    reentrantERC20,
+  };
 }
 
-async function runSubmitBatchTest(opts: {
-  batchSize: number
-}) {
-    const {
-      signers,
-      peggyId,
-      powers,
-      validators,
-      peggy,
-      testERC20,
-    } = await prep()
+async function runSubmitBatchTest(opts: { batchSize: number }) {
+  const {
+    signers,
+    peggyId,
+    powers,
+    validators,
+    peggy,
+    testERC20,
+  } = await prep();
 
+  // Lock tokens in peggy
+  // ====================
+  await sendToCosmos(peggy, testERC20, 1000);
 
+  expect(
+    (await testERC20.functions.balanceOf(peggy.address))[0].toNumber(),
+    "peggy does not have correct balance after sendToCosmos"
+  ).to.equal(1000);
 
-    // Lock tokens in peggy
-    // ====================
-    await sendToCosmos(peggy, testERC20, 1000)
+  expect(
+    (
+      await testERC20.functions.balanceOf(await signers[0].getAddress())
+    )[0].toNumber(),
+    "msg.sender does not have correct balance after sendToCosmos"
+  ).to.equal(9000);
 
-    expect(
-      (await testERC20.functions.balanceOf(peggy.address))[0].toNumber(),
-      "peggy does not have correct balance after sendToCosmos"
-    ).to.equal(1000);
+  // Prepare tx batch
+  // ================
+  const txBatch = await prepareTxBatch(opts.batchSize, signers);
+  const batchNonce = 1;
+  const batchTimeout = 10000;
 
-    expect(
-      (await testERC20.functions.balanceOf(await signers[0].getAddress()))[0].toNumber(),
-      "msg.sender does not have correct balance after sendToCosmos"
-    ).to.equal(9000);
+  // Using submitBatch method
+  // ========================
+  let methodName = ethers.utils.formatBytes32String("transactionBatch");
 
+  let digest = ethers.utils.keccak256(
+    ethers.utils.defaultAbiCoder.encode(
+      [
+        "bytes32",
+        "bytes32",
+        "uint256[]",
+        "address[]",
+        "uint256[]",
+        "uint256",
+        "address",
+        "uint256",
+      ],
+      [
+        peggyId,
+        methodName,
+        txBatch.amounts,
+        txBatch.destinations,
+        txBatch.fees,
+        batchNonce,
+        testERC20.address,
+        batchTimeout,
+      ]
+    )
+  );
 
+  let sigs = await signHash(validators, digest);
 
+  await peggy.submitBatch(
+    await getSignerAddresses(validators),
+    powers,
+    0,
 
-    // Prepare tx batch
-    // ================
-    const txBatch = await prepareTxBatch(opts.batchSize, signers)
-    const batchNonce = 1
-    const batchTimeout = 10000
+    sigs.v,
+    sigs.r,
+    sigs.s,
 
+    txBatch.amounts,
+    txBatch.destinations,
+    txBatch.fees,
+    1,
+    testERC20.address,
+    batchTimeout
+  );
 
+  expect(
+    (
+      await testERC20.functions.balanceOf(await signers[5].getAddress())
+    )[0].toNumber(),
+    "first address in tx batch does not have correct balance after submitBatch"
+  ).to.equal(1);
 
+  expect(
+    (
+      await testERC20.functions.balanceOf(
+        await signers[5 + txBatch.numTxs - 1].getAddress()
+      )
+    )[0].toNumber(),
+    "last address in tx batch does not have correct balance after submitBatch"
+  ).to.equal(1);
 
-    // Using submitBatch method
-    // ========================
-    let methodName = ethers.utils.formatBytes32String(
-      "transactionBatch"
-    );
+  expect(
+    (await testERC20.functions.balanceOf(peggy.address))[0].toNumber(),
+    "peggy does not have correct balance after submitBatch"
+    // Each tx in batch is worth 1 coin sent + 1 coin fee
+  ).to.equal(1000 - txBatch.numTxs * 2);
 
-    let digest = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
-        [
-          "bytes32",
-          "bytes32",
-          "uint256[]",
-          "address[]",
-          "uint256[]",
-          "uint256",
-          "address",
-          "uint256"
-        ],
-        [
-          peggyId,
-          methodName,
-          txBatch.amounts,
-          txBatch.destinations,
-          txBatch.fees,
-          batchNonce,
-          testERC20.address,
-          batchTimeout
-        ]
-      ));
-
-    let sigs = await signHash(validators, digest);
-
-    await peggy.submitBatch(
-      await getSignerAddresses(validators),
-      powers,
-      0,
-
-      sigs.v,
-      sigs.r,
-      sigs.s,
-
-      txBatch.amounts,
-      txBatch.destinations,
-      txBatch.fees,
-      1,
-      testERC20.address,
-      batchTimeout
-    );
-
-    expect(
-      (await testERC20.functions.balanceOf(await signers[5].getAddress()))[0].toNumber(),
-      "first address in tx batch does not have correct balance after submitBatch"
-    ).to.equal(1);
-
-    expect(
-      (await testERC20.functions.balanceOf(await signers[5 + txBatch.numTxs - 1].getAddress()))[0].toNumber(),
-      "last address in tx batch does not have correct balance after submitBatch"
-    ).to.equal(1);
-
-    expect(
-      (await testERC20.functions.balanceOf(peggy.address))[0].toNumber(),
-      "peggy does not have correct balance after submitBatch"
-      // Each tx in batch is worth 1 coin sent + 1 coin fee
-    ).to.equal(1000 - (txBatch.numTxs * 2));
-
-    expect(
-      (await testERC20.functions.balanceOf(await signers[0].getAddress()))[0].toNumber(),
-      "msg.sender does not have correct balance after submitBatch"
-      // msg.sender has received 1 coin in fees for each tx
-    ).to.equal(9000 + txBatch.numTxs);
+  expect(
+    (
+      await testERC20.functions.balanceOf(await signers[0].getAddress())
+    )[0].toNumber(),
+    "msg.sender does not have correct balance after submitBatch"
+    // msg.sender has received 1 coin in fees for each tx
+  ).to.equal(9000 + txBatch.numTxs);
 }
 
 async function runLogicCallTest(opts: {
-  batchSize: number
+  batchSize: number;
+  reentrant?: boolean;
 }) {
-    const {
-      signers,
-      peggyId,
-      powers,
-      validators,
-      peggy,
-      testERC20,
-    } = await prep()
+  const {
+    signers,
+    peggyId,
+    powers,
+    validators,
+    peggy,
+    testERC20,
+    reentrantERC20,
+  } = await prep();
 
-    const TestTokenBatchMiddleware = await ethers.getContractFactory("TestTokenBatchMiddleware");
-    const tokenBatchMiddleware = (await TestTokenBatchMiddleware.deploy()) as TestTokenBatchMiddleware;
-    await tokenBatchMiddleware.transferOwnership(peggy.address);
+  const TestTokenBatchMiddleware = await ethers.getContractFactory(
+    "TestTokenBatchMiddleware"
+  );
+  const tokenBatchMiddleware = (await TestTokenBatchMiddleware.deploy()) as TestTokenBatchMiddleware;
+  await tokenBatchMiddleware.transferOwnership(peggy.address);
 
+  // Lock tokens in peggy
+  // ====================
+  await sendToCosmos(peggy, testERC20, 1000);
 
-    // Lock tokens in peggy
-    // ====================
-    await sendToCosmos(peggy, testERC20, 1000)
+  expect(
+    (await testERC20.functions.balanceOf(peggy.address))[0].toNumber(),
+    "peggy does not have correct balance after sendToCosmos"
+  ).to.equal(1000);
 
-    expect(
-      (await testERC20.functions.balanceOf(peggy.address))[0].toNumber(),
-      "peggy does not have correct balance after sendToCosmos"
-    ).to.equal(1000);
+  expect(
+    (
+      await testERC20.functions.balanceOf(await signers[0].getAddress())
+    )[0].toNumber(),
+    "msg.sender does not have correct balance after sendToCosmos"
+  ).to.equal(9000);
 
-    expect(
-      (await testERC20.functions.balanceOf(await signers[0].getAddress()))[0].toNumber(),
-      "msg.sender does not have correct balance after sendToCosmos"
-    ).to.equal(9000);
+  // Preparing tx batch
+  // ===================================
+  const txBatch = await prepareTxBatch(opts.batchSize, signers);
+  const batchNonce = 1;
 
+  // Using logicCall method
+  // ========================
+  const methodName = ethers.utils.formatBytes32String("logicCall");
 
+  let logicCallArgs = {
+    transferAmounts: [txBatch.numTxs], // transferAmounts
+    transferTokenContracts: [testERC20.address], // transferTokenContracts
+    feeAmounts: [txBatch.numTxs], // feeAmounts
+    feeTokenContracts: [testERC20.address], // feeTokenContracts
+    logicContractAddress: tokenBatchMiddleware.address, // logicContractAddress
+    payload: tokenBatchMiddleware.interface.encodeFunctionData("submitBatch", [
+      txBatch.amounts,
+      txBatch.destinations,
+      opts.reentrant ? reentrantERC20.address : testERC20.address,
+    ]), // payload
+    timeOut: 4766922941000, // timeOut, Far in the future
+    invalidationId: ethers.utils.hexZeroPad(testERC20.address, 32), // invalidationId
+    invalidationNonce: 1, // invalidationNonce
+  };
 
+  const digest = ethers.utils.keccak256(
+    ethers.utils.defaultAbiCoder.encode(
+      [
+        "bytes32", // peggyId
+        "bytes32", // methodName
+        "uint256[]", // transferAmounts
+        "address[]", // transferTokenContracts
+        "uint256[]", // feeAmounts
+        "address[]", // feeTokenContracts
+        "address", // logicContractAddress
+        "bytes", // payload
+        "uint256", // timeOut
+        "bytes32", // invalidationId
+        "uint256", // invalidationNonce
+      ],
+      [
+        peggyId,
+        methodName,
+        logicCallArgs.transferAmounts,
+        logicCallArgs.transferTokenContracts,
+        logicCallArgs.feeAmounts,
+        logicCallArgs.feeTokenContracts,
+        logicCallArgs.logicContractAddress,
+        logicCallArgs.payload,
+        logicCallArgs.timeOut,
+        logicCallArgs.invalidationId,
+        logicCallArgs.invalidationNonce,
+      ]
+    )
+  );
 
-    // Preparing tx batch
-    // ===================================
-    const txBatch = await prepareTxBatch(opts.batchSize, signers)
-    const batchNonce = 1
+  const sigs = await signHash(validators, digest);
 
+  await peggy.submitLogicCall(
+    await getSignerAddresses(validators),
+    powers,
+    0,
 
+    sigs.v,
+    sigs.r,
+    sigs.s,
+    logicCallArgs
+  );
 
+  expect(
+    (
+      await testERC20.functions.balanceOf(await signers[5].getAddress())
+    )[0].toNumber(),
+    "first address in tx batch does not have correct balance after submitLogicCall"
+  ).to.equal(1);
 
-    // Using logicCall method
-    // ========================
-    const methodName = ethers.utils.formatBytes32String(
-        "logicCall"
-      );
+  expect(
+    (
+      await testERC20.functions.balanceOf(
+        await signers[5 + txBatch.numTxs - 1].getAddress()
+      )
+    )[0].toNumber(),
+    "last address in tx batch does not have correct balance after submitLogicCall"
+  ).to.equal(1);
 
-    let logicCallArgs = {
-      transferAmounts: [txBatch.numTxs], // transferAmounts
-      transferTokenContracts: [testERC20.address], // transferTokenContracts
-      feeAmounts: [txBatch.numTxs], // feeAmounts
-      feeTokenContracts: [testERC20.address], // feeTokenContracts
-      logicContractAddress: tokenBatchMiddleware.address, // logicContractAddress
-      payload: tokenBatchMiddleware.interface.encodeFunctionData("submitBatch",[txBatch.amounts, txBatch.destinations, testERC20.address]), // payload
-      timeOut: 4766922941000, // timeOut, Far in the future
-      invalidationId: ethers.utils.hexZeroPad(testERC20.address, 32), // invalidationId
-      invalidationNonce: 1 // invalidationNonce
-    }
-  
-    const digest = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(
-          [
-            "bytes32", // peggyId
-            "bytes32", // methodName
-            "uint256[]", // transferAmounts
-            "address[]", // transferTokenContracts
-            "uint256[]", // feeAmounts
-            "address[]", // feeTokenContracts
-            "address", // logicContractAddress
-            "bytes", // payload
-            "uint256", // timeOut
-            "bytes32", // invalidationId
-            "uint256" // invalidationNonce
-          ],
-          [
-            peggyId,
-            methodName,
-            logicCallArgs.transferAmounts,
-            logicCallArgs.transferTokenContracts,
-            logicCallArgs.feeAmounts,
-            logicCallArgs.feeTokenContracts,
-            logicCallArgs.logicContractAddress,
-            logicCallArgs.payload,
-            logicCallArgs.timeOut,
-            logicCallArgs.invalidationId,
-            logicCallArgs.invalidationNonce
-          ]
-        ));
-  
-      const sigs = await signHash(validators, digest);
-  
-      await peggy.submitLogicCall(
-        await getSignerAddresses(validators),
-        powers,
-        0,
-  
-        sigs.v,
-        sigs.r,
-        sigs.s,
-        logicCallArgs
-      );
+  expect(
+    (await testERC20.functions.balanceOf(peggy.address))[0].toNumber(),
+    "peggy does not have correct balance after submitLogicCall"
+    // Each tx in batch is worth 1 coin sent + 1 coin fee
+  ).to.equal(1000 - txBatch.numTxs * 2);
 
-      expect(
-        (await testERC20.functions.balanceOf(await signers[5].getAddress()))[0].toNumber(),
-        "first address in tx batch does not have correct balance after submitLogicCall"
-      ).to.equal(1);
-  
-      expect(
-        (await testERC20.functions.balanceOf(await signers[5 + txBatch.numTxs - 1].getAddress()))[0].toNumber(),
-        "last address in tx batch does not have correct balance after submitLogicCall"
-      ).to.equal(1);
-  
-      expect(
-        (await testERC20.functions.balanceOf(peggy.address))[0].toNumber(),
-        "peggy does not have correct balance after submitLogicCall"
-        // Each tx in batch is worth 1 coin sent + 1 coin fee
-      ).to.equal(1000 - (txBatch.numTxs * 2));
-  
-      expect(
-        (await testERC20.functions.balanceOf(await signers[0].getAddress()))[0].toNumber(),
-        "msg.sender does not have correct balance after submitLogicCall"
-        // msg.sender has received 1 coin in fees for each tx
-      ).to.equal(9000 + txBatch.numTxs);
+  expect(
+    (
+      await testERC20.functions.balanceOf(await signers[0].getAddress())
+    )[0].toNumber(),
+    "msg.sender does not have correct balance after submitLogicCall"
+    // msg.sender has received 1 coin in fees for each tx
+  ).to.equal(9000 + txBatch.numTxs);
 }
 
 describe("Compare gas usage of old submitBatch method vs new logicCall method submitting one batch", function () {
   it("Large batch", async function () {
-    await runSubmitBatchTest({batchSize: 10})
-    await runLogicCallTest({batchSize: 10})
+    await runSubmitBatchTest({ batchSize: 10 });
+    await runLogicCallTest({ batchSize: 10 });
   });
 
   it("Small batch", async function () {
-    await runSubmitBatchTest({batchSize: 1})
-    await runLogicCallTest({batchSize: 1})
+    await runSubmitBatchTest({ batchSize: 1 });
+    await runLogicCallTest({ batchSize: 1 });
+  });
+
+  it("Reentrant", async function () {
+    await expect(
+      runLogicCallTest({ batchSize: 1, reentrant: true })
+    ).to.be.revertedWith("ReentrancyGuard: reentrant call");
   });
 });

--- a/solidity/test/submitBatch.ts
+++ b/solidity/test/submitBatch.ts
@@ -8,12 +8,11 @@ import {
   makeCheckpoint,
   signHash,
   makeTxBatchHash,
-  examplePowers
+  examplePowers,
 } from "../test-utils/pure";
 
 chai.use(solidity);
 const { expect } = chai;
-
 
 async function runTest(opts: {
   // Issues with the tx batch
@@ -29,9 +28,6 @@ async function runTest(opts: {
   malformedCurrentValset?: boolean;
   batchTimeout?: boolean;
 }) {
-
-
-
   // Prep and deploy contract
   // ========================
   const signers = await ethers.getSigners();
@@ -43,10 +39,8 @@ async function runTest(opts: {
   const {
     peggy,
     testERC20,
-    checkpoint: deployCheckpoint
+    checkpoint: deployCheckpoint,
   } = await deployContracts(peggyId, validators, powers, powerThreshold);
-
-
 
   // Transfer out to Cosmos, locking coins
   // =====================================
@@ -56,8 +50,6 @@ async function runTest(opts: {
     ethers.utils.formatBytes32String("myCosmosAddress"),
     1000
   );
-
-
 
   // Prepare batch
   // ===============================
@@ -77,21 +69,18 @@ async function runTest(opts: {
     txFees.pop();
   }
 
-  let batchTimeout = ethers.provider.blockNumber + 1000
+  let batchTimeout = ethers.provider.blockNumber + 1000;
   if (opts.batchTimeout) {
-    batchTimeout = ethers.provider.blockNumber - 1
+    batchTimeout = ethers.provider.blockNumber - 1;
   }
-  let batchNonce = 1
+  let batchNonce = 1;
   if (opts.batchNonceNotHigher) {
-    batchNonce = 0
+    batchNonce = 0;
   }
-
 
   // Call method
   // ===========
-  const methodName = ethers.utils.formatBytes32String(
-    "transactionBatch"
-  );
+  const methodName = ethers.utils.formatBytes32String("transactionBatch");
   let abiEncoded = ethers.utils.defaultAbiCoder.encode(
     [
       "bytes32",
@@ -101,7 +90,7 @@ async function runTest(opts: {
       "uint256[]",
       "uint256",
       "address",
-      "uint256"
+      "uint256",
     ],
     [
       peggyId,
@@ -111,7 +100,7 @@ async function runTest(opts: {
       txFees,
       batchNonce,
       testERC20.address,
-      batchTimeout
+      batchTimeout,
     ]
   );
   let digest = ethers.utils.keccak256(abiEncoded);
@@ -214,7 +203,6 @@ describe("submitBatch tests", function () {
     );
   });
 
-
   it("throws on bad validator sig", async function () {
     await expect(runTest({ badValidatorSig: true })).to.be.revertedWith(
       "Validator signature does not match"
@@ -236,13 +224,10 @@ describe("submitBatch tests", function () {
   });
 });
 
-
 // This test produces a hash for the contract which should match what is being used in the Go unit tests. It's here for
 // the use of anyone updating the Go tests.
 describe("submitBatch Go test hash", function () {
   it("produces good hash", async function () {
-
-
     // Prep and deploy contract
     // ========================
     const signers = await ethers.getSigners();
@@ -253,19 +238,16 @@ describe("submitBatch Go test hash", function () {
     const {
       peggy,
       testERC20,
-      checkpoint: deployCheckpoint
+      checkpoint: deployCheckpoint,
     } = await deployContracts(peggyId, validators, powers, powerThreshold);
-
 
     // Prepare batch
     // ===============================
-    const txAmounts = [1]
-    const txFees = [1]
+    const txAmounts = [1];
+    const txFees = [1];
     const txDestinations = await getSignerAddresses([signers[5]]);
-    const batchNonce = 1
-    const batchTimeout = ethers.provider.blockNumber + 1000
-
-
+    const batchNonce = 1;
+    const batchTimeout = ethers.provider.blockNumber + 1000;
 
     // Transfer out to Cosmos, locking coins
     // =====================================
@@ -275,8 +257,6 @@ describe("submitBatch Go test hash", function () {
       ethers.utils.formatBytes32String("myCosmosAddress"),
       1000
     );
-
-
 
     // Call method
     // ===========
@@ -302,27 +282,26 @@ describe("submitBatch Go test hash", function () {
         txFees,
         batchNonce,
         testERC20.address,
-        batchTimeout
+        batchTimeout,
       ]
     );
     const batchDigest = ethers.utils.keccak256(abiEncodedBatch);
 
     console.log("elements in batch digest:", {
-      "peggyId": peggyId,
-      "batchMethodName": batchMethodName,
-      "txAmounts": txAmounts,
-      "txDestinations": txDestinations,
-      "txFees": txFees,
-      "batchNonce": batchNonce,
-      "batchTimeout": batchTimeout,
-      "tokenContract": testERC20.address
-    })
-    console.log("abiEncodedBatch:", abiEncodedBatch)
-    console.log("batchDigest:", batchDigest)
+      peggyId: peggyId,
+      batchMethodName: batchMethodName,
+      txAmounts: txAmounts,
+      txDestinations: txDestinations,
+      txFees: txFees,
+      batchNonce: batchNonce,
+      batchTimeout: batchTimeout,
+      tokenContract: testERC20.address,
+    });
+    console.log("abiEncodedBatch:", abiEncodedBatch);
+    console.log("batchDigest:", batchDigest);
 
     const sigs = await signHash(validators, batchDigest);
     const currentValsetNonce = 0;
-
 
     await peggy.submitBatch(
       await getSignerAddresses(validators),
@@ -341,4 +320,4 @@ describe("submitBatch Go test hash", function () {
       batchTimeout
     );
   });
-})
+});


### PR DESCRIPTION
This commit closes #221 and #190.

It reverses the order of logic contract calling and fee payment in `submitLogicCall`, and it places a reentrancy guard on `submitBatch` `submitLogicCall`, and `sendToCosmos`.

Note that I have not thought of any vulnerabilities caused by re-entrancy, and it costs a small amount of extra gas to use the guard. If we can have an auditor verify that no vulnerabilities are possible without this guard, we should remove it.