### PR TITLE
Improvements to RPC parsing and startup checks

### DIFF
--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "parking_lot",
  "pin-project 0.4.27",
  "smallvec",
- "tokio 0.2.24",
+ "tokio",
  "tokio-util",
  "trust-dns-proto",
  "trust-dns-resolver",
@@ -37,7 +37,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project 0.4.27",
- "tokio 0.2.24",
+ "tokio",
  "tokio-util",
 ]
 
@@ -145,7 +145,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "smallvec",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -603,9 +603,9 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "contact"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b4eda72aa18d723bec6bba3dd2b77cca097cc03fbaaef8fb2e0e2b5dffa87c"
+checksum = "db05b618e1e787aad1f089f0e2a2638131e8541b3bf7c18348bda718a3a98885"
 dependencies = [
  "actix-web",
  "deep_space",
@@ -614,7 +614,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio 1.2.0",
+ "tokio",
 ]
 
 [[package]]
@@ -664,7 +664,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha3",
- "tokio 0.2.24",
+ "tokio",
  "tonic",
  "web30",
 ]
@@ -1066,7 +1066,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.24",
+ "tokio",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -1174,7 +1174,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.2",
  "socket2",
- "tokio 0.2.24",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -1657,7 +1657,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio 0.2.24",
+ "tokio",
  "tonic",
  "web30",
 ]
@@ -1727,7 +1727,7 @@ dependencies = [
  "rand 0.8.0",
  "serde",
  "serde_derive",
- "tokio 0.2.24",
+ "tokio",
  "tonic",
  "url",
  "web30",
@@ -2114,7 +2114,7 @@ dependencies = [
  "peggy_utils",
  "serde",
  "serde_derive",
- "tokio 0.2.24",
+ "tokio",
  "tonic",
  "web30",
 ]
@@ -2542,7 +2542,7 @@ dependencies = [
  "rand 0.8.0",
  "serde",
  "serde_derive",
- "tokio 0.2.24",
+ "tokio",
  "tonic",
  "url",
  "web30",
@@ -2673,16 +2673,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
-dependencies = [
- "autocfg",
- "pin-project-lite 0.2.0",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,7 +2690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c4b08c5f4208e699ede3df2520aca2e82401b2de33f45e96696a074480be594"
 dependencies = [
  "openssl",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -2715,7 +2705,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.1.11",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]
@@ -2737,7 +2727,7 @@ dependencies = [
  "pin-project 0.4.27",
  "prost",
  "prost-derive",
- "tokio 0.2.24",
+ "tokio",
  "tokio-util",
  "tower",
  "tower-balance",
@@ -2790,7 +2780,7 @@ dependencies = [
  "pin-project 0.4.27",
  "rand 0.7.3",
  "slab",
- "tokio 0.2.24",
+ "tokio",
  "tower-discover",
  "tower-layer",
  "tower-load",
@@ -2808,7 +2798,7 @@ checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio 0.2.24",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2839,7 +2829,7 @@ checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio 0.2.24",
+ "tokio",
  "tower-layer",
  "tower-load",
  "tower-service",
@@ -2854,7 +2844,7 @@ dependencies = [
  "futures-core",
  "log",
  "pin-project 0.4.27",
- "tokio 0.2.24",
+ "tokio",
  "tower-discover",
  "tower-service",
 ]
@@ -2877,7 +2867,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
 dependencies = [
- "tokio 0.2.24",
+ "tokio",
  "tower-service",
 ]
 
@@ -2891,7 +2881,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "log",
- "tokio 0.2.24",
+ "tokio",
  "tower-service",
 ]
 
@@ -2903,7 +2893,7 @@ checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio 0.2.24",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -2921,7 +2911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
 dependencies = [
  "pin-project 0.4.27",
- "tokio 0.2.24",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -3003,7 +2993,7 @@ dependencies = [
  "rand 0.7.3",
  "smallvec",
  "thiserror",
- "tokio 0.2.24",
+ "tokio",
  "url",
 ]
 
@@ -3023,7 +3013,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio 0.2.24",
+ "tokio",
  "trust-dns-proto",
 ]
 
@@ -3202,7 +3192,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio 0.2.24",
+ "tokio",
 ]
 
 [[package]]

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -603,9 +603,9 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "contact"
-version = "0.3.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133a6c95f65caf3e358dfdf788454d1c641c83e8910fb8014247a1c4b7d62942"
+checksum = "79b4eda72aa18d723bec6bba3dd2b77cca097cc03fbaaef8fb2e0e2b5dffa87c"
 dependencies = [
  "actix-web",
  "deep_space",

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "actix-rt",
  "clarity",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "orchestrator"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
  "actix-rt",
  "clarity",
@@ -2072,7 +2072,7 @@ checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "register_delegate_keys"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
  "actix-rt",
  "clarity",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "relayer"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
  "actix",
  "actix-rt",

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -603,9 +603,9 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "contact"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f839691480c313391c53e699fc58618e9d13900b9fe81179650858f9a5156a1"
+checksum = "133a6c95f65caf3e358dfdf788454d1c641c83e8910fb8014247a1c4b7d62942"
 dependencies = [
  "actix-web",
  "deep_space",

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "parking_lot",
  "pin-project 0.4.27",
  "smallvec",
- "tokio",
+ "tokio 0.2.24",
  "tokio-util",
  "trust-dns-proto",
  "trust-dns-resolver",
@@ -37,7 +37,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.24",
  "tokio-util",
 ]
 
@@ -145,7 +145,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "smallvec",
- "tokio",
+ "tokio 0.2.24",
 ]
 
 [[package]]
@@ -603,9 +603,9 @@ checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "contact"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325ab26c8ccf3135d4465829eb008b8ff41f40014fa612c64669f632fda74eae"
+checksum = "0f839691480c313391c53e699fc58618e9d13900b9fe81179650858f9a5156a1"
 dependencies = [
  "actix-web",
  "deep_space",
@@ -614,7 +614,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio",
+ "tokio 1.2.0",
 ]
 
 [[package]]
@@ -664,7 +664,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha3",
- "tokio",
+ "tokio 0.2.24",
  "tonic",
  "web30",
 ]
@@ -1066,7 +1066,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 0.2.24",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -1174,7 +1174,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.2",
  "socket2",
- "tokio",
+ "tokio 0.2.24",
  "tower-service",
  "tracing",
  "want",
@@ -1657,7 +1657,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio",
+ "tokio 0.2.24",
  "tonic",
  "web30",
 ]
@@ -1716,6 +1716,7 @@ dependencies = [
 name = "peggy_utils"
 version = "0.1.0"
 dependencies = [
+ "actix",
  "clarity",
  "contact",
  "deep_space",
@@ -1726,7 +1727,7 @@ dependencies = [
  "rand 0.8.0",
  "serde",
  "serde_derive",
- "tokio",
+ "tokio 0.2.24",
  "tonic",
  "url",
  "web30",
@@ -2113,7 +2114,7 @@ dependencies = [
  "peggy_utils",
  "serde",
  "serde_derive",
- "tokio",
+ "tokio 0.2.24",
  "tonic",
  "web30",
 ]
@@ -2541,7 +2542,7 @@ dependencies = [
  "rand 0.8.0",
  "serde",
  "serde_derive",
- "tokio",
+ "tokio 0.2.24",
  "tonic",
  "url",
  "web30",
@@ -2672,6 +2673,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+dependencies = [
+ "autocfg",
+ "pin-project-lite 0.2.0",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,7 +2700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c4b08c5f4208e699ede3df2520aca2e82401b2de33f45e96696a074480be594"
 dependencies = [
  "openssl",
- "tokio",
+ "tokio 0.2.24",
 ]
 
 [[package]]
@@ -2704,7 +2715,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.1.11",
- "tokio",
+ "tokio 0.2.24",
 ]
 
 [[package]]
@@ -2726,7 +2737,7 @@ dependencies = [
  "pin-project 0.4.27",
  "prost",
  "prost-derive",
- "tokio",
+ "tokio 0.2.24",
  "tokio-util",
  "tower",
  "tower-balance",
@@ -2779,7 +2790,7 @@ dependencies = [
  "pin-project 0.4.27",
  "rand 0.7.3",
  "slab",
- "tokio",
+ "tokio 0.2.24",
  "tower-discover",
  "tower-layer",
  "tower-load",
@@ -2797,7 +2808,7 @@ checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.24",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2828,7 +2839,7 @@ checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.24",
  "tower-layer",
  "tower-load",
  "tower-service",
@@ -2843,7 +2854,7 @@ dependencies = [
  "futures-core",
  "log",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.24",
  "tower-discover",
  "tower-service",
 ]
@@ -2866,7 +2877,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
 dependencies = [
- "tokio",
+ "tokio 0.2.24",
  "tower-service",
 ]
 
@@ -2880,7 +2891,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "log",
- "tokio",
+ "tokio 0.2.24",
  "tower-service",
 ]
 
@@ -2892,7 +2903,7 @@ checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.24",
  "tower-layer",
  "tower-service",
 ]
@@ -2910,7 +2921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
 dependencies = [
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.24",
  "tower-layer",
  "tower-service",
 ]
@@ -2992,7 +3003,7 @@ dependencies = [
  "rand 0.7.3",
  "smallvec",
  "thiserror",
- "tokio",
+ "tokio 0.2.24",
  "url",
 ]
 
@@ -3012,7 +3023,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio",
+ "tokio 0.2.24",
  "trust-dns-proto",
 ]
 
@@ -3191,7 +3202,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio",
+ "tokio 0.2.24",
 ]
 
 [[package]]

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "actix-rt",
  "clarity",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "orchestrator"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "actix-rt",
  "clarity",
@@ -2072,7 +2072,7 @@ checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "register_delegate_keys"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "actix-rt",
  "clarity",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "relayer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "actix",
  "actix-rt",

--- a/orchestrator/client/Cargo.toml
+++ b/orchestrator/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 

--- a/orchestrator/client/Cargo.toml
+++ b/orchestrator/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client"
-version = "0.1.0"
+version = "0.4.0"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 

--- a/orchestrator/client/Cargo.toml
+++ b/orchestrator/client/Cargo.toml
@@ -11,7 +11,7 @@ peggy_utils = {path = "../peggy_utils"}
 peggy_proto = {path = "../peggy_proto/"}
 
 deep_space = "0.2"
-contact = "0.3"
+contact = "0.4"
 serde_derive = "1.0"
 clarity = "0.4"
 docopt = "1"

--- a/orchestrator/client/src/main.rs
+++ b/orchestrator/client/src/main.rs
@@ -19,6 +19,7 @@ use cosmos_peggy::send::{send_request_batch, send_to_eth};
 use deep_space::address::Address as CosmosAddress;
 use deep_space::{coin::Coin, private_key::PrivateKey as CosmosPrivateKey};
 use docopt::Docopt;
+use env_logger::Env;
 use ethereum_peggy::send_to_cosmos::send_to_cosmos;
 use peggy_utils::connection_prep::create_rpc_connections;
 use std::{time::Duration, u128};
@@ -96,7 +97,7 @@ lazy_static! {
 
 #[actix_rt::main]
 async fn main() {
-    env_logger::init();
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
     // On Linux static builds we need to probe ssl certs path to be able to
     // do TLS stuff.
     openssl_probe::init_ssl_cert_env_vars();

--- a/orchestrator/client/src/main.rs
+++ b/orchestrator/client/src/main.rs
@@ -21,7 +21,7 @@ use deep_space::{coin::Coin, private_key::PrivateKey as CosmosPrivateKey};
 use docopt::Docopt;
 use env_logger::Env;
 use ethereum_peggy::send_to_cosmos::send_to_cosmos;
-use peggy_utils::connection_prep::create_rpc_connections;
+use peggy_utils::connection_prep::{check_for_eth, check_for_fee_denom, create_rpc_connections};
 use std::{time::Duration, u128};
 
 const TIMEOUT: Duration = Duration::from_secs(60);
@@ -136,6 +136,7 @@ async fn main() {
             amount: 1u64.into(),
         };
         let eth_dest: EthAddress = args.flag_eth_destination.parse().unwrap();
+        check_for_fee_denom(&peggy_denom, cosmos_address, &contact).await;
 
         let balances = contact
             .get_balances(cosmos_address)
@@ -202,6 +203,7 @@ async fn main() {
         let web3 = connections.web3.unwrap();
         let cosmos_dest: CosmosAddress = args.flag_cosmos_destination.parse().unwrap();
         let ethereum_public_key = ethereum_key.to_public_key().unwrap();
+        check_for_eth(ethereum_public_key, &web3).await;
 
         let erc20_balance = web3
             .get_erc20_balance(erc20_address, ethereum_public_key)

--- a/orchestrator/cosmos_peggy/Cargo.toml
+++ b/orchestrator/cosmos_peggy/Cargo.toml
@@ -11,7 +11,7 @@ peggy_utils = {path = "../peggy_utils"}
 ethereum_peggy = {path = "../ethereum_peggy"}
 peggy_proto = {path = "../peggy_proto/"}
 
-contact = "0.3.2"
+contact = "0.3"
 deep_space = "0.2"
 serde_derive = "1.0"
 clarity = "0.4"

--- a/orchestrator/cosmos_peggy/Cargo.toml
+++ b/orchestrator/cosmos_peggy/Cargo.toml
@@ -11,7 +11,7 @@ peggy_utils = {path = "../peggy_utils"}
 ethereum_peggy = {path = "../ethereum_peggy"}
 peggy_proto = {path = "../peggy_proto/"}
 
-contact = "0.3"
+contact = "0.4"
 deep_space = "0.2"
 serde_derive = "1.0"
 clarity = "0.4"

--- a/orchestrator/cosmos_peggy/src/utils.rs
+++ b/orchestrator/cosmos_peggy/src/utils.rs
@@ -5,42 +5,24 @@ use tokio::time::delay_for;
 
 pub async fn wait_for_next_cosmos_block(contact: &Contact, timeout: Duration) {
     let start = Instant::now();
-    let current_block = contact
-        .get_latest_block()
-        .await
-        .unwrap()
-        .block
-        .unwrap()
-        .last_commit
-        .height;
-    while current_block
-        == contact
-            .get_latest_block()
-            .await
-            .unwrap()
-            .block
-            .unwrap()
-            .last_commit
-            .height
-    {
-        delay_for(Duration::from_secs(1)).await;
-        if Instant::now() - start > timeout {
-            panic!("Cosmos chain took too long to produce a block!");
+    let mut last_height = None;
+    while Instant::now() - start < timeout {
+        if let Ok(block_response) = contact.get_latest_block().await {
+            if let Some(block) = block_response.block {
+                if last_height.is_some() && block.last_commit.height > last_height.unwrap() {
+                    return;
+                }
+                last_height = Some(block.last_commit.height);
+            }
         }
+        delay_for(Duration::from_secs(1)).await;
     }
+    panic!("Cosmos chain took too long to produce a block!");
 }
 
 pub async fn wait_for_cosmos_online(contact: &Contact, timeout: Duration) {
-    let start = Instant::now();
-    let mut current_block = contact.get_latest_block().await;
-    while current_block.is_err() {
-        delay_for(Duration::from_secs(1)).await;
-        current_block = contact.get_latest_block().await;
-        if Instant::now() - start > timeout {
-            panic!("Cosmos chain took too long to start!");
-        }
-    }
     // we have a block now, wait for a few more.
+    wait_for_next_cosmos_block(contact, timeout).await;
     wait_for_next_cosmos_block(contact, timeout).await;
     wait_for_next_cosmos_block(contact, timeout).await;
 }

--- a/orchestrator/cosmos_peggy/src/utils.rs
+++ b/orchestrator/cosmos_peggy/src/utils.rs
@@ -10,6 +10,7 @@ pub async fn wait_for_next_cosmos_block(contact: &Contact, timeout: Duration) {
         .await
         .unwrap()
         .block
+        .unwrap()
         .last_commit
         .height;
     while current_block
@@ -18,6 +19,7 @@ pub async fn wait_for_next_cosmos_block(contact: &Contact, timeout: Duration) {
             .await
             .unwrap()
             .block
+            .unwrap()
             .last_commit
             .height
     {

--- a/orchestrator/orchestrator/Cargo.toml
+++ b/orchestrator/orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 

--- a/orchestrator/orchestrator/Cargo.toml
+++ b/orchestrator/orchestrator/Cargo.toml
@@ -20,7 +20,7 @@ peggy_utils = {path = "../peggy_utils"}
 peggy_proto = {path = "../peggy_proto/"}
 
 deep_space = "0.2"
-contact = "0.3"
+contact = "0.4"
 serde_derive = "1.0"
 clarity = "0.4"
 docopt = "1"

--- a/orchestrator/orchestrator/Cargo.toml
+++ b/orchestrator/orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator"
-version = "0.2.1"
+version = "0.4.0"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 

--- a/orchestrator/orchestrator/src/main.rs
+++ b/orchestrator/orchestrator/src/main.rs
@@ -23,17 +23,13 @@ mod oracle_resync;
 use crate::main_loop::orchestrator_main_loop;
 use clarity::Address as EthAddress;
 use clarity::PrivateKey as EthPrivateKey;
-use deep_space::address::Address as CosmosAddress;
 use deep_space::private_key::PrivateKey as CosmosPrivateKey;
 use docopt::Docopt;
 use main_loop::{ETH_ORACLE_LOOP_SPEED, ETH_SIGNER_LOOP_SPEED};
-use peggy_proto::peggy::query_client::QueryClient as PeggyQueryClient;
-use peggy_proto::peggy::QueryDelegateKeysByEthAddress;
-use peggy_proto::peggy::QueryDelegateKeysByOrchestratorAddress;
+use peggy_utils::connection_prep::check_delegate_addresses;
 use peggy_utils::connection_prep::create_rpc_connections;
 use relayer::main_loop::LOOP_SPEED as RELAYER_LOOP_SPEED;
-use std::{cmp::min, process::exit};
-use tonic::transport::Channel;
+use std::cmp::min;
 
 #[derive(Debug, Deserialize)]
 struct Args {
@@ -118,8 +114,26 @@ async fn main() {
         public_eth_key, public_cosmos_key
     );
 
+    // todo check if RPC is syncing
     let mut grpc = connections.grpc.clone().unwrap();
     check_delegate_addresses(&mut grpc, public_eth_key, public_cosmos_key).await;
+
+    let contact = connections.contact.clone().unwrap();
+    let mut found = false;
+    for balance in contact
+        .get_balances(public_cosmos_key)
+        .await
+        .unwrap()
+        .result
+    {
+        if balance.denom.contains(&fee_denom) {
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        panic!("You have specified that fees should be paid in {} but account {} has no balance of that token!", fee_denom, public_cosmos_key)
+    }
 
     // TODO this should wait here if the cosmos node is still syncing.
 
@@ -133,77 +147,4 @@ async fn main() {
         fee_denom,
     )
     .await;
-}
-
-/// This function checks the orchestrator delegate addresses
-/// for consistency what this means is that it takes the Ethereum
-/// address and Orchestrator address from the Orchestrator and checks
-/// that both are registered and internally consistent.
-async fn check_delegate_addresses(
-    client: &mut PeggyQueryClient<Channel>,
-    delegate_eth_address: EthAddress,
-    delegate_orchestrator_address: CosmosAddress,
-) {
-    let eth_response = client
-        .get_delegate_key_by_eth(QueryDelegateKeysByEthAddress {
-            eth_address: delegate_eth_address.to_string(),
-        })
-        .await;
-    let orchestrator_response = client
-        .get_delegate_key_by_orchestrator(QueryDelegateKeysByOrchestratorAddress {
-            orchestrator_address: delegate_orchestrator_address.to_string(),
-        })
-        .await;
-    match (eth_response, orchestrator_response) {
-        (Ok(e), Ok(o)) => {
-            let e = e.into_inner();
-            let o = o.into_inner();
-            let req_delegate_orchestrator_address: CosmosAddress =
-                e.orchestrator_address.parse().unwrap();
-            let req_delegate_eth_address: EthAddress = o.eth_address.parse().unwrap();
-            if req_delegate_eth_address != delegate_eth_address
-                && req_delegate_orchestrator_address != delegate_orchestrator_address
-            {
-                error!("Your Delegate Ethereum and Orchestrator addresses are both incorrect!");
-                error!(
-                    "You provided {}  Correct Value {}",
-                    delegate_eth_address, req_delegate_eth_address
-                );
-                error!(
-                    "You provided {}  Correct Value {}",
-                    delegate_orchestrator_address, req_delegate_orchestrator_address
-                );
-                error!("In order to resolve this issue you should double check your input value or re-register your delegate keys");
-                exit(1);
-            } else if req_delegate_eth_address != delegate_eth_address {
-                error!("Your Delegate Ethereum address is incorrect!");
-                error!(
-                    "You provided {}  Correct Value {}",
-                    delegate_eth_address, req_delegate_eth_address
-                );
-                error!("In order to resolve this issue you should double check how you input your eth private key");
-                exit(1);
-            } else if req_delegate_orchestrator_address != delegate_orchestrator_address {
-                error!("Your Delegate Orchestrator address is incorrect!");
-                error!(
-                    "You provided {}  Correct Value {}",
-                    delegate_eth_address, req_delegate_eth_address
-                );
-                error!("In order to resolve this issue you should double check how you input your Orchestrator address phrase, make sure you didn't use your Validator phrase!");
-                exit(1);
-            }
-
-            if e.validator_address != o.validator_address {
-                error!("You are using delegate keys from two different validator addresses!");
-                error!("If you get this error message I would just blow everything away and start again");
-                exit(1);
-            }
-        }
-        (Err(_), Ok(_)) | (Ok(_), Err(_)) => {
-            panic!("Failed to check delegate Eth address. Maybe try running the program again? If that doesn't work try registering delegate keys again")
-        }
-        (Err(_), Err(_)) => {
-            panic!("Delegate addresses are not set! Please Register your delegate keys and make sure your Althea binary is updated!")
-        }
-    }
 }

--- a/orchestrator/orchestrator/src/oracle_resync.rs
+++ b/orchestrator/orchestrator/src/oracle_resync.rs
@@ -103,7 +103,7 @@ pub async fn get_last_checked_block(
             || erc20_deployed_events.is_err()
             || logic_call_executed_events.is_err()
         {
-            error!("Failed to get blockchain events while resyncing, is your Eth node working?");
+            error!("Failed to get blockchain events while resyncing, is your Eth node working? If you see only one of these it's fine",);
             delay_for(RETRY_TIME).await;
             continue;
         }

--- a/orchestrator/peggy_utils/Cargo.toml
+++ b/orchestrator/peggy_utils/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 peggy_proto = {path = "../peggy_proto/"}
 
 deep_space = "0.2"
-contact = "0.3"
+contact = "0.4"
 web30 = "0.10"
 clarity = "0.4"
 num256 = "0.3"

--- a/orchestrator/peggy_utils/Cargo.toml
+++ b/orchestrator/peggy_utils/Cargo.toml
@@ -23,3 +23,4 @@ log = "0.4"
 url = "2"
 [dev_dependencies]
 rand = "0.8"
+actix = "0.10"

--- a/orchestrator/peggy_utils/src/connection_prep.rs
+++ b/orchestrator/peggy_utils/src/connection_prep.rs
@@ -275,11 +275,28 @@ pub async fn wait_for_cosmos_node_ready(contact: &Contact) {
                 if !val.syncing {
                     break;
                 } else {
-                    info!("Cosmos node is syncing or waiting for the chain to start. Standing by")
+                    info!("Cosmos node is syncing Standing by")
                 }
             }
             Err(e) => warn!(
                 "Could not get syncing status, is your Cosmos node up? {:?}",
+                e
+            ),
+        }
+        delay_for(WAIT_TIME).await;
+    }
+    loop {
+        let res = contact.get_latest_block().await;
+        match res {
+            Ok(val) => {
+                if val.block.is_some() {
+                    break;
+                } else {
+                    info!("Cosmos node is waiting for the chain to start, Standing by")
+                }
+            }
+            Err(e) => warn!(
+                "Could not get chain launch status, is your Cosmos node up? {:?}",
                 e
             ),
         }

--- a/orchestrator/peggy_utils/src/connection_prep.rs
+++ b/orchestrator/peggy_utils/src/connection_prep.rs
@@ -306,7 +306,7 @@ pub async fn check_delegate_addresses(
             orchestrator_address: delegate_orchestrator_address.to_string(),
         })
         .await;
-    info!("{:?} {:?}", eth_response, orchestrator_response);
+    trace!("{:?} {:?}", eth_response, orchestrator_response);
     match (eth_response, orchestrator_response) {
         (Ok(e), Ok(o)) => {
             let e = e.into_inner();
@@ -352,11 +352,17 @@ pub async fn check_delegate_addresses(
                 exit(1);
             }
         }
-        (Err(_), Ok(_)) | (Ok(_), Err(_)) => {
-            panic!("Failed to check delegate Eth address. Maybe try running the program again? If that doesn't work try registering delegate keys again")
+        (Err(_), Ok(_o)) => {
+            error!("Your delegate Ethereum address is incorrect, please double check you private key. If you can't locate the correct private key register your delegate keys again and use the new value");
+            exit(1);
+        }
+        (Ok(_e), Err(_)) => {
+            error!("Your delegate Cosmos address is incorrect, please double check your phrase. If you can't locate the correct phrase register your delegate keys again and use the new value");
+            exit(1);
         }
         (Err(_), Err(_)) => {
-            panic!("Delegate addresses are not set! Please Register your delegate keys and make sure your Althea binary is updated!")
+            error!("Delegate keys are not set! Please Register your delegate keys");
+            exit(1);
         }
     }
 }

--- a/orchestrator/peggy_utils/src/connection_prep.rs
+++ b/orchestrator/peggy_utils/src/connection_prep.rs
@@ -383,3 +383,27 @@ pub async fn check_delegate_addresses(
         }
     }
 }
+
+/// Checks if a given denom, used for fees is in the provided address
+pub async fn check_for_fee_denom(fee_denom: &str, address: CosmosAddress, contact: &Contact) {
+    let mut found = false;
+    for balance in contact.get_balances(address).await.unwrap().result {
+        if balance.denom.contains(&fee_denom) {
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        error!("You have specified that fees should be paid in {} but account {} has no balance of that token!", fee_denom, address);
+        exit(1);
+    }
+}
+
+/// Checks the user has some Ethereum in their address to pay for things
+pub async fn check_for_eth(address: EthAddress, web3: &Web3) {
+    let balance = web3.eth_get_balance(address).await.unwrap();
+    if balance == 0u8.into() {
+        error!("You don't have any Ethereum! You will need to send some to {} for this program to work. Dust will do for basic operations, more info about average relaying costs will be presented as the program runs", address);
+        exit(1);
+    }
+}

--- a/orchestrator/register_delegate_keys/Cargo.toml
+++ b/orchestrator/register_delegate_keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "register_delegate_keys"
-version = "0.2.1"
+version = "0.4.0"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 

--- a/orchestrator/register_delegate_keys/Cargo.toml
+++ b/orchestrator/register_delegate_keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "register_delegate_keys"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 

--- a/orchestrator/register_delegate_keys/Cargo.toml
+++ b/orchestrator/register_delegate_keys/Cargo.toml
@@ -16,7 +16,7 @@ peggy_utils = {path = "../peggy_utils"}
 peggy_proto = {path = "../peggy_proto/"}
 
 deep_space = "0.2"
-contact = "0.3"
+contact = "0.4"
 serde_derive = "1.0"
 clarity = "0.4"
 docopt = "1"

--- a/orchestrator/register_delegate_keys/src/main.rs
+++ b/orchestrator/register_delegate_keys/src/main.rs
@@ -6,7 +6,7 @@ extern crate serde_derive;
 extern crate lazy_static;
 
 use clarity::PrivateKey as EthPrivateKey;
-use cosmos_peggy::{send::update_peggy_delegate_addresses, utils::wait_for_cosmos_online};
+use cosmos_peggy::send::update_peggy_delegate_addresses;
 use deep_space::{coin::Coin, mnemonic::Mnemonic, private_key::PrivateKey as CosmosPrivateKey};
 use docopt::Docopt;
 use peggy_utils::connection_prep::{create_rpc_connections, wait_for_cosmos_node_ready};

--- a/orchestrator/relayer/Cargo.toml
+++ b/orchestrator/relayer/Cargo.toml
@@ -19,7 +19,7 @@ peggy_utils = {path = "../peggy_utils"}
 peggy_proto = {path = "../peggy_proto/"}
 
 deep_space = "0.2"
-contact = "0.3"
+contact = "0.4"
 serde_derive = "1.0"
 clarity = "0.4"
 docopt = "1"

--- a/orchestrator/relayer/Cargo.toml
+++ b/orchestrator/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relayer"
-version = "0.2.1"
+version = "0.4.0"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 

--- a/orchestrator/relayer/Cargo.toml
+++ b/orchestrator/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relayer"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 

--- a/orchestrator/relayer/src/main.rs
+++ b/orchestrator/relayer/src/main.rs
@@ -3,6 +3,7 @@ use crate::main_loop::LOOP_SPEED;
 use clarity::Address as EthAddress;
 use clarity::PrivateKey as EthPrivateKey;
 use docopt::Docopt;
+use env_logger::Env;
 use peggy_utils::connection_prep::{create_rpc_connections, wait_for_cosmos_node_ready};
 
 pub mod batch_relaying;
@@ -52,7 +53,7 @@ lazy_static! {
 
 #[actix_rt::main]
 async fn main() {
-    env_logger::init();
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
     // On Linux static builds we need to probe ssl certs path to be able to
     // do TLS stuff.
     openssl_probe::init_ssl_cert_env_vars();

--- a/orchestrator/relayer/src/main.rs
+++ b/orchestrator/relayer/src/main.rs
@@ -4,7 +4,9 @@ use clarity::Address as EthAddress;
 use clarity::PrivateKey as EthPrivateKey;
 use docopt::Docopt;
 use env_logger::Env;
-use peggy_utils::connection_prep::{create_rpc_connections, wait_for_cosmos_node_ready};
+use peggy_utils::connection_prep::{
+    check_for_eth, create_rpc_connections, wait_for_cosmos_node_ready,
+};
 
 pub mod batch_relaying;
 pub mod find_latest_valset;
@@ -85,11 +87,13 @@ async fn main() {
     info!("Ethereum Address: {}", public_eth_key);
 
     let contact = connections.contact.clone().unwrap();
+    let web3 = connections.web3.clone().unwrap();
 
     // check if the cosmos node is syncing, if so wait for it
     // we can't move any steps above this because they may fail on an incorrect
     // historic chain state while syncing occurs
     wait_for_cosmos_node_ready(&contact).await;
+    check_for_eth(public_eth_key, &web3).await;
 
     relayer_main_loop(
         ethereum_key,

--- a/orchestrator/relayer/src/main_loop.rs
+++ b/orchestrator/relayer/src/main_loop.rs
@@ -33,7 +33,7 @@ pub async fn relayer_main_loop(
         )
         .await;
         if current_valset.is_err() {
-            error!("Could not get current valset!");
+            error!("Could not get current valset! {:?}", current_valset);
             continue;
         }
         let current_valset = current_valset.unwrap();

--- a/orchestrator/test_runner/Cargo.toml
+++ b/orchestrator/test_runner/Cargo.toml
@@ -17,7 +17,7 @@ peggy_proto = {path = "../peggy_proto/"}
 orchestrator = {path = "../orchestrator/"}
 
 deep_space = "0.2"
-contact = "0.3"
+contact = "0.4"
 serde_derive = "1.0"
 clarity = "0.4"
 docopt = "1"

--- a/orchestrator/test_runner/src/happy_path_v2.rs
+++ b/orchestrator/test_runner/src/happy_path_v2.rs
@@ -8,7 +8,7 @@ use crate::utils::get_user_key;
 use crate::utils::send_one_eth;
 use crate::{COSMOS_NODE_GRPC, TOTAL_TIMEOUT};
 use actix::Arbiter;
-use clarity::{abi::Token, Address as EthAddress};
+use clarity::Address as EthAddress;
 use clarity::{PrivateKey as EthPrivateKey, Uint256};
 use contact::client::Contact;
 use cosmos_peggy::send::{send_request_batch, send_to_eth};

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "hardhat-test",
+  "name": "gravity-contracts",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
This fixes some pretty glaring issues in the RPC startup parsing and
testing.

This patch also moves the code to a location where it can be called in
the integration tests.

Finally a new check was added validating that the orchestrator address
does in fact have the fee token that is being specified to spend.