### PR TITLE
Remove claims slashing

### DIFF
--- a/spec/slashing-spec.md
+++ b/spec/slashing-spec.md
@@ -17,9 +17,9 @@ This slashing condition is triggered when a validator does not sign a validator 
 
 To deal with scenario 2, GRAVSLASH-02 will also need to slash validators who are no longer validating, but are still in the unbonding period. This means that when a validator leaves the validator set, they will need to keep running their equipment for 2 weeks. This is unusual for a Cosmos chain, and may not be accepted by the validators. Research is ongoing for ways to allow validators to stop signing before the unbonding period is fully over.
 
-## GRAVSLASH-03: Submitting incorrect Eth oracle claim
+## GRAVSLASH-03: Submitting incorrect Eth oracle claim - INTENTIONALLY NOT IMPLEMENTED
 
-The Ethereum oracle code (currently mostly contained in attestation.go), is a key part of Gravity. It allows the Gravity module to have knowledge of events that have occured on Ethereum, such as deposits and executed batches. GRAVSLASH-03 is intended to punish validators who submit a claim for an event that never happened on Ethereum.
+The Ethereum oracle code (currently mostly contained in attestation.go), is a key part of Gravity. It allows the Gravity module to have knowledge of events that have occurred on Ethereum, such as deposits and executed batches. GRAVSLASH-03 is intended to punish validators who submit a claim for an event that never happened on Ethereum.
 
 **Implementation considerations**
 


### PR DESCRIPTION
After much discussion there seems to be a soft agreement that Claims
slashing is at best useless and at worst a threat to the Cosmos chain
running it.

If a group of validators can make false claims, they can also take over
the chain, as they must have 66% of the total voting power. So slashing
them won't exactly stop them from doing anything.

If a validator make an incorrect claim, due to an ehtereum fork or any
other unintentional reason they will be slashed. Potentially causing
chaos and even taking down the chain running Gravity if there is some
unexpected fork or other bad behavior on the EVM chain.

So we have an attack that slashing doesn't prevent and a worst case that
could halt the chain through no fault of any validator. When put in
those terms this condition simply doesn't make sense and should be
removed.