### PR TITLE
Compute normalized power difference

### DIFF
--- a/module/x/gravity/types/types.go
+++ b/module/x/gravity/types/types.go
@@ -67,11 +67,9 @@ func (b BridgeValidators) Sort() {
 // TODO: this needs to be potentially refactored
 func (b BridgeValidators) PowerDiff(c BridgeValidators) float64 {
 	powers := map[string]int64{}
-	var totalB int64
 	// loop over b and initialize the map with their powers
 	for _, bv := range b {
 		powers[bv.EthereumAddress] = int64(bv.Power)
-		totalB += int64(bv.Power)
 	}
 
 	// subtract c powers from powers in the map, initializing
@@ -90,7 +88,7 @@ func (b BridgeValidators) PowerDiff(c BridgeValidators) float64 {
 		delta += math.Abs(float64(v))
 	}
 
-	return math.Abs(delta / float64(totalB))
+	return math.Abs(delta / float64(math.MaxUint32))
 }
 
 // TotalPower returns the total power in the bridge validator set

--- a/module/x/gravity/types/types_test.go
+++ b/module/x/gravity/types/types_test.go
@@ -72,16 +72,16 @@ func TestValsetPowerDiff(t *testing.T) {
 		},
 		"one": {
 			start: BridgeValidators{
-				{Power: 1, EthereumAddress: "0x479FFc856Cdfa0f5D1AE6Fa61915b01351A7773D"},
-				{Power: 1, EthereumAddress: "0x8E91960d704Df3fF24ECAb78AB9df1B5D9144140"},
-				{Power: 2, EthereumAddress: "0xF14879a175A2F1cEFC7c616f35b6d9c2b0Fd8326"},
+				{Power: 1073741823, EthereumAddress: "0x479FFc856Cdfa0f5D1AE6Fa61915b01351A7773D"},
+				{Power: 1073741823, EthereumAddress: "0x8E91960d704Df3fF24ECAb78AB9df1B5D9144140"},
+				{Power: 2147483646, EthereumAddress: "0xF14879a175A2F1cEFC7c616f35b6d9c2b0Fd8326"},
 			},
 			diff: BridgeValidators{
-				{Power: 1, EthereumAddress: "0x479FFc856Cdfa0f5D1AE6Fa61915b01351A7773D"},
-				{Power: 1, EthereumAddress: "0x8E91960d704Df3fF24ECAb78AB9df1B5D9144140"},
-				{Power: 3, EthereumAddress: "0xF14879a175A2F1cEFC7c616f35b6d9c2b0Fd8326"},
+				{Power: 858993459, EthereumAddress: "0x479FFc856Cdfa0f5D1AE6Fa61915b01351A7773D"},
+				{Power: 858993459, EthereumAddress: "0x8E91960d704Df3fF24ECAb78AB9df1B5D9144140"},
+				{Power: 2576980377, EthereumAddress: "0xF14879a175A2F1cEFC7c616f35b6d9c2b0Fd8326"},
 			},
-			exp: 0.25,
+			exp: 0.2,
 		},
 		"real world": {
 			start: BridgeValidators{
@@ -104,7 +104,7 @@ func TestValsetPowerDiff(t *testing.T) {
 				{Power: 291759231, EthereumAddress: "0xF14879a175A2F1cEFC7c616f35b6d9c2b0Fd8326"},
 				{Power: 6785098, EthereumAddress: "0x37A0603dA2ff6377E5C7f75698dabA8EE4Ba97B8"},
 			},
-			exp: 0.010000000023283065,
+			exp: 0.010000000011641532,
 		},
 	}
 	for msg, spec := range specs {


### PR DESCRIPTION
Previously this code was producing an absolute power difference, this
creates an issue where depending on the amount of active validtors and
inflation in the system the change between any two blocks may always be
greater than the 5% threshold for producing a new validator set.

This minor change normalizes the powers, the difference will always
be expressed as a percentage of uint32 max, since all powers in the
Ethereum contract always sum to that value.