### PR TITLE
Remove testing endblocker

### DIFF
--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -266,31 +266,3 @@ func BatchSlashing(ctx sdk.Context, k keeper.Keeper, params types.Params) {
 
 	}
 }
-
-// TestingEndBlocker is a second endblocker function only imported in the Gravity codebase itself
-// if you are a consuming Cosmos chain DO NOT IMPORT THIS, it simulates a chain using the arbitrary
-// logic API to request logic calls
-func TestingEndBlocker(ctx sdk.Context, k keeper.Keeper) {
-	// if this is nil we have not set our test outgoing logic call yet
-	if k.GetOutgoingLogicCall(ctx, []byte("GravityTesting"), 0).Payload == nil {
-		// TODO this call isn't actually very useful for testing, since it always
-		// throws, being just junk data that's expected. But it prevents us from checking
-		// the full lifecycle of the call. We need to find some way for this to read data
-		// and encode a simple testing call, probably to one of the already deployed ERC20
-		// contracts so that we can get the full lifecycle.
-		token := []*types.ERC20Token{{
-			Contract: "0x7580bfe88dd3d07947908fae12d95872a260f2d8",
-			Amount:   sdk.NewIntFromUint64(5000),
-		}}
-		_ = types.OutgoingLogicCall{
-			Transfers:            token,
-			Fees:                 token,
-			LogicContractAddress: "0x510ab76899430424d209a6c9a5b9951fb8a6f47d",
-			Payload:              []byte("fake bytes"),
-			Timeout:              10000,
-			InvalidationId:       []byte("GravityTesting"),
-			InvalidationNonce:    1,
-		}
-		//k.SetOutgoingLogicCall(ctx, &call)
-	}
-}

--- a/module/x/gravity/module.go
+++ b/module/x/gravity/module.go
@@ -155,9 +155,6 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {}
 // EndBlock implements app module
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
 	EndBlocker(ctx, am.keeper)
-	// this begin blocker is only for testing purposes, don't import into your
-	// own chain running gravity
-	TestingEndBlocker(ctx, am.keeper)
 	return []abci.ValidatorUpdate{}
 }
 


### PR DESCRIPTION
This patch removes the testing endblocker, which was a bad hack to try
and test the arbitrary logic integration without importing a module that
actaully uses arbitrary logic.

We still don't have a good way to test arbitrary logic end to end in
this repo and what I recomend we do in order to faciliate that is add
the ability for users to create arbitrary logic calls as part of the
core Gravity featureset.

But this patch does not do that, it just removes the ill concieved
testing endblocker.