### PR TITLE
sequential valset nonces

### DIFF
--- a/module/x/gravity/keeper/keeper_delegate_key.go
+++ b/module/x/gravity/keeper/keeper_delegate_key.go
@@ -132,6 +132,8 @@ func (k Keeper) GetCurrentValset(ctx sdk.Context) *types.Valset {
 		rewardToken, rewardAmount = k.RewardToERC20Lookup(ctx, reward)
 	}
 
-	// TODO: make the nonce an incrementing one (i.e. fetch last nonce from state, increment, set here)
-	return types.NewValset(uint64(ctx.BlockHeight()), uint64(ctx.BlockHeight()), bridgeValidators, rewardAmount, rewardToken)
+	// Update the valset nonce for use in the new valset
+	var valsetNonce = k.IncrementLatestValsetNonce(ctx)
+
+	return types.NewValset(valsetNonce, uint64(ctx.BlockHeight()), bridgeValidators, rewardAmount, rewardToken)
 }

--- a/module/x/gravity/keeper/keeper_test.go
+++ b/module/x/gravity/keeper/keeper_test.go
@@ -189,20 +189,23 @@ func TestLastSlashedValsetNonce(t *testing.T) {
 	lastSlashedValsetNonce = k.GetLastSlashedValsetNonce(ctx)
 	assert.Equal(t, lastSlashedValsetNonce, uint64(3))
 
-	// when maxHeight < lastSlashedValsetNonce, len(unslashedValsets) should be zero
-	unslashedValsets = k.GetUnSlashedValsets(ctx, uint64(2))
+	lastSlashedValset := k.GetValset(ctx, lastSlashedValsetNonce)
+
+	// when valset height + signedValsetsWindow > current block height, len(unslashedValsets) should be zero
+	unslashedValsets = k.GetUnSlashedValsets(ctx, uint64(ctx.BlockHeight()))
 	assert.Equal(t, len(unslashedValsets), 0)
 
-	// when maxHeight == lastSlashedValsetNonce, len(unslashedValsets) should be zero
-	unslashedValsets = k.GetUnSlashedValsets(ctx, uint64(3))
+	// when lastSlashedValset height + signedValsetsWindow == BlockHeight, len(unslashedValsets) should be zero
+	heightDiff := uint64(ctx.BlockHeight()) - lastSlashedValset.Height
+	unslashedValsets = k.GetUnSlashedValsets(ctx, heightDiff)
 	assert.Equal(t, len(unslashedValsets), 0)
 
-	// when maxHeight > lastSlashedValsetNonce && maxHeight <= latestValsetNonce
-	unslashedValsets = k.GetUnSlashedValsets(ctx, uint64(6))
+	// when signedValsetsWindow is between lastSlashedValset height and latest valset's height
+	unslashedValsets = k.GetUnSlashedValsets(ctx, heightDiff-2)
 	assert.Equal(t, len(unslashedValsets), 2)
 
-	// when maxHeight > latestValsetNonce
-	unslashedValsets = k.GetUnSlashedValsets(ctx, uint64(15))
+	// when signedValsetsWindow > latest valset's height
+	unslashedValsets = k.GetUnSlashedValsets(ctx, heightDiff-6)
 	assert.Equal(t, len(unslashedValsets), 6)
 	fmt.Println("unslashedValsetsRange", unslashedValsets)
 }

--- a/module/x/gravity/keeper/keeper_valset.go
+++ b/module/x/gravity/keeper/keeper_valset.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 
@@ -203,6 +204,73 @@ func (k Keeper) IterateValsetBySlashedValsetNonce(ctx sdk.Context, lastSlashedVa
 			break
 		}
 	}
+}
+
+// GetCurrentValset gets powers from the store and normalizes them
+// into an integer percentage with a resolution of uint32 Max meaning
+// a given validators 'gravity power' is computed as
+// Cosmos power for that validator / total cosmos power = x / uint32 Max
+// where x is the voting power on the gravity contract. This allows us
+// to only use integer division which produces a known rounding error
+// from truncation equal to the ratio of the validators
+// Cosmos power / total cosmos power ratio, leaving us at uint32 Max - 1
+// total voting power. This is an acceptable rounding error since floating
+// point may cause consensus problems if different floating point unit
+// implementations are involved.
+//
+// 'total cosmos power' has an edge case, if a validator has not set their
+// Ethereum key they are not included in the total. If they where control
+// of the bridge could be lost in the following situation.
+//
+// If we have 100 total power, and 100 total power joins the validator set
+// the new validators hold more than 33% of the bridge power, if we generate
+// and submit a valset and they don't have their eth keys set they can never
+// update the validator set again and the bridge and all its' funds are lost.
+// For this reason we exclude validators with unset eth keys from validator sets
+func (k Keeper) GetCurrentValset(ctx sdk.Context) *types.Valset {
+	validators := k.StakingKeeper.GetBondedValidatorsByPower(ctx)
+	// allocate enough space for all validators, but len zero, we then append
+	// so that we have an array with extra capacity but the correct length depending
+	// on how many validators have keys set.
+	bridgeValidators := make([]*types.BridgeValidator, 0, len(validators))
+	var totalPower uint64
+	// TODO someone with in depth info on Cosmos staking should determine
+	// if this is doing what I think it's doing
+	for _, validator := range validators {
+		val := validator.GetOperator()
+
+		p := uint64(k.StakingKeeper.GetLastValidatorPower(ctx, val))
+
+		if ethAddr, found := k.GetEthAddressByValidator(ctx, val); found {
+			bv := &types.BridgeValidator{Power: p, EthereumAddress: ethAddr}
+			bridgeValidators = append(bridgeValidators, bv)
+			totalPower += p
+		}
+	}
+	// normalize power values
+	for i := range bridgeValidators {
+		bridgeValidators[i].Power = sdk.NewUint(bridgeValidators[i].Power).MulUint64(math.MaxUint32).QuoUint64(totalPower).Uint64()
+	}
+
+	// get the reward from the params store
+	reward := k.GetParams(ctx).ValsetReward
+	var rewardToken string
+	var rewardAmount sdk.Int
+	if !reward.IsValid() || reward.IsZero() {
+		// the case where a validator has 'no reward'. The 'no reward' value is interpreted as having a zero
+		// address for the ERC20 token and a zero value for the reward amount. Since we store a coin with the
+		// params, a coin with a blank denom and/or zero amount is interpreted in this way.
+		rewardToken = "0x0000000000000000000000000000000000000000"
+		rewardAmount = sdk.NewIntFromUint64(0)
+
+	} else {
+		rewardToken, rewardAmount = k.RewardToERC20Lookup(ctx, reward)
+	}
+
+	// Update the valset nonce for use in the new valset
+	var valsetNonce = k.IncrementLatestValsetNonce(ctx)
+
+	return types.NewValset(valsetNonce, uint64(ctx.BlockHeight()), bridgeValidators, rewardAmount, rewardToken)
 }
 
 /////////////////////////////

--- a/module/x/gravity/keeper/querier_test.go
+++ b/module/x/gravity/keeper/querier_test.go
@@ -157,7 +157,7 @@ func TestLastValsetRequests(t *testing.T) {
 		"limit at 5": {
 			expResp: []byte(`[
 {
-  "nonce": "105",
+  "nonce": "6",
   "height": "105",
   "reward_amount": "0",
   "reward_token": "0x0000000000000000000000000000000000000000",
@@ -189,7 +189,7 @@ func TestLastValsetRequests(t *testing.T) {
   ]
 },
 {
-  "nonce": "104",
+  "nonce": "5",
   "height": "104",
   "reward_amount": "0",
   "reward_token": "0x0000000000000000000000000000000000000000",
@@ -217,7 +217,7 @@ func TestLastValsetRequests(t *testing.T) {
   ]
 },
 {
-  "nonce": "103",
+  "nonce": "4",
   "height": "103",
   "reward_amount": "0",
   "reward_token": "0x0000000000000000000000000000000000000000",
@@ -241,7 +241,7 @@ func TestLastValsetRequests(t *testing.T) {
   ]
 },
 {
-  "nonce": "102",
+  "nonce": "3",
   "height": "102",
   "reward_amount": "0",
   "reward_token": "0x0000000000000000000000000000000000000000",
@@ -261,7 +261,7 @@ func TestLastValsetRequests(t *testing.T) {
   ]
 },
 {
-  "nonce": "101",
+  "nonce": "2",
   "height": "101",
   "reward_amount": "0",
   "reward_token": "0x0000000000000000000000000000000000000000",
@@ -314,7 +314,7 @@ func TestPendingValsetRequests(t *testing.T) {
 		"find valset": {
 			expResp: []byte(`[
                                   {
-                                    "nonce": "105",
+                                    "nonce": "6",
                                     "members": [
                                       {
                                         "power": "715827882",
@@ -346,7 +346,7 @@ func TestPendingValsetRequests(t *testing.T) {
                                     "reward_token": "0x0000000000000000000000000000000000000000"
                                   },
                                   {
-                                    "nonce": "104",
+                                    "nonce": "5",
                                     "members": [
                                       {
                                         "power": "858993459",
@@ -374,7 +374,7 @@ func TestPendingValsetRequests(t *testing.T) {
                                     "reward_token": "0x0000000000000000000000000000000000000000"
                                   },
                                   {
-                                    "nonce": "103",
+                                    "nonce": "4",
                                     "members": [
                                       {
                                         "power": "1073741823",
@@ -398,7 +398,7 @@ func TestPendingValsetRequests(t *testing.T) {
                                     "reward_token": "0x0000000000000000000000000000000000000000"
                                   },
                                   {
-                                    "nonce": "102",
+                                    "nonce": "3",
                                     "members": [
                                       {
                                         "power": "1431655765",
@@ -418,7 +418,7 @@ func TestPendingValsetRequests(t *testing.T) {
                                     "reward_token": "0x0000000000000000000000000000000000000000"
                                   },
                                   {
-                                    "nonce": "101",
+                                    "nonce": "2",
                                     "members": [
                                       {
                                         "power": "2147483647",
@@ -434,7 +434,7 @@ func TestPendingValsetRequests(t *testing.T) {
                                     "reward_token": "0x0000000000000000000000000000000000000000"
                                   },
                                   {
-                                    "nonce": "100",
+                                    "nonce": "1",
                                     "members": [
                                       {
                                         "power": "4294967295",
@@ -858,7 +858,7 @@ func TestQueryCurrentValset(t *testing.T) {
 	currentValset := input.GravityKeeper.GetCurrentValset(ctx)
 
 	bridgeVal := types.BridgeValidator{EthereumAddress: ethAddress, Power: 4294967295}
-	expectedValset := types.NewValset(1234567, 1234567, []*types.BridgeValidator{&bridgeVal}, sdk.NewIntFromUint64(0), "0x0000000000000000000000000000000000000000")
+	expectedValset := types.NewValset(1, 1234567, []*types.BridgeValidator{&bridgeVal}, sdk.NewIntFromUint64(0), "0x0000000000000000000000000000000000000000")
 	assert.Equal(t, expectedValset, currentValset)
 }
 


### PR DESCRIPTION
Changing the valset nonces from being blockheight based to sequential by making use of the LatestValsetNonce key in keeper