### PR TITLE
Disabling the ARBITRARY_LOGIC integration test

### DIFF
--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -9,4 +9,6 @@ bash all-up-test.sh VALSET_STRESS
 bash all-up-test.sh BATCH_STRESS
 bash all-up-test.sh HAPPY_PATH_V2
 bash all-up-test.sh VALIDATOR_OUT
-bash all-up-test.sh ARBITRARY_LOGIC
+# An alchemy api key is necessary for this arbitrary logic test, so we are disabling it
+#bash all-up-test.sh ARBITRARY_LOGIC
+echo "All tests succeeded!"


### PR DESCRIPTION
Disabling ARBITRARY_LOGIC test since it only runs on github actions