### PR TITLE
Moving valset nonce update outside of valset getter function

### DIFF
--- a/module/x/gravity/abci_test.go
+++ b/module/x/gravity/abci_test.go
@@ -78,8 +78,8 @@ func TestValsetSlashing_ValsetCreated_After_ValidatorBonded(t *testing.T) {
 	vs := pk.GetCurrentValset(ctx)
 	height := uint64(ctx.BlockHeight()) - (params.SignedValsetsWindow + 1)
 	vs.Height = height
-	nonce := pk.GetLatestValsetNonce(ctx)
-	vs.Nonce = nonce
+
+	vs.Nonce = pk.GetLatestValsetNonce(ctx) + 1
 	pk.StoreValsetUnsafe(ctx, vs)
 
 	for i, val := range keeper.AccAddrs {
@@ -129,8 +129,7 @@ func TestValsetSlashing_UnbondingValidator_UnbondWindow_NotExpired(t *testing.T)
 	ctx = ctx.WithBlockHeight(valsetRequestHeight)
 	vs := pk.GetCurrentValset(ctx)
 	vs.Height = uint64(valsetRequestHeight)
-	nonce := pk.IncrementLatestValsetNonce(ctx)
-	vs.Nonce = nonce
+	vs.Nonce = pk.GetLatestValsetNonce(ctx) + 1
 	pk.StoreValsetUnsafe(ctx, vs)
 
 	// Start Unbonding validators

--- a/module/x/gravity/keeper/querier_test.go
+++ b/module/x/gravity/keeper/querier_test.go
@@ -137,8 +137,8 @@ func TestAllValsetConfirmsBynonce(t *testing.T) {
 func TestLastValsetRequests(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
-	// seed with requests
-	for i := 0; i < 6; i++ {
+	// seed with maxValsetRequestsReturns + 1 requests
+	for i := 0; i < maxValsetRequestsReturned+1; i++ {
 		var validators []sdk.ValAddress
 		for j := 0; j <= i; j++ {
 			// add an validator each block
@@ -153,7 +153,7 @@ func TestLastValsetRequests(t *testing.T) {
 
 	specs := map[string]struct {
 		expResp []byte
-	}{
+	}{ // Expect only maxValsetRequestsReturns back
 		"limit at 5": {
 			expResp: []byte(`[
 {


### PR DESCRIPTION
LatestValsetNonce is now incremented in SetValsetRequest rather than GetCurrentValset

Closes  #279