### PR TITLE
Cherry-pick jtremback's non-reentrant updateValset modifier from the upstream repo

### DIFF
--- a/solidity/contracts/Gravity.sol
+++ b/solidity/contracts/Gravity.sol
@@ -230,7 +230,7 @@ contract Gravity is ReentrancyGuard {
 		uint8[] memory _v,
 		bytes32[] memory _r,
 		bytes32[] memory _s
-	) public {
+	) public nonReentrant {
 		// CHECKS
 
 		// Check that the valset nonce is greater than the old one


### PR DESCRIPTION
Original title: Add nonReentrant modifier to updateValset

Original description: This is almost definitely not necessary but better safe than sorry