### PR TITLE
Enable exhaustivestruct linter

### DIFF
--- a/module/.golangci.yml
+++ b/module/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - dogsled
     # - dupl
     - errcheck
+    - exhaustivestruct
     # - funlen
     # - gochecknoglobals
     # - gochecknoinits
@@ -45,6 +46,12 @@ linters-settings:
     # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
     # default is false: such cases aren't reported by default.
     check-blank: true
+  exhaustivestruct:
+    # Struct Patterns is a list of expressions to match struct packages and names
+    # The struct packages have the form example.com/package.ExampleStruct
+    # The matching patterns can use matching syntax from https://pkg.go.dev/path#Match
+    # If this list is empty, all structs are tested.
+    struct-patterns:
   golint:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0

--- a/module/app/app.go
+++ b/module/app/app.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	"github.com/gorilla/mux"
@@ -85,6 +86,8 @@ import (
 	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
 	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
 
 	// unnamed import of statik for swagger UI support
 	_ "github.com/cosmos/cosmos-sdk/client/docs/statik"
@@ -239,6 +242,7 @@ func NewGravityApp(
 	tKeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
 	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
 
+	//nolint: exhaustivestruct
 	var app = &Gravity{
 		BaseApp:           bApp,
 		legacyAmino:       legacyAmino,
@@ -542,7 +546,31 @@ func NewGravityApp(
 		// that in-memory capabilities get regenerated on app restart.
 		// Note that since this reads from the store, we can only perform it when
 		// `loadLatest` is set to true.
-		ctx := app.BaseApp.NewUncachedContext(true, tmproto.Header{})
+		ctx := app.BaseApp.NewUncachedContext(true, tmproto.Header{
+			Version: tmversion.Consensus{
+				Block: 0,
+				App:   0,
+			},
+			ChainID: "",
+			Height:  0,
+			Time:    time.Time{},
+			LastBlockId: tmproto.BlockID{
+				Hash: []byte{},
+				PartSetHeader: tmproto.PartSetHeader{
+					Total: 0,
+					Hash:  []byte{},
+				},
+			},
+			LastCommitHash:     []byte{},
+			DataHash:           []byte{},
+			ValidatorsHash:     []byte{},
+			NextValidatorsHash: []byte{},
+			ConsensusHash:      []byte{},
+			AppHash:            []byte{},
+			LastResultsHash:    []byte{},
+			EvidenceHash:       []byte{},
+			ProposerAddress:    []byte{},
+		})
 		app.capabilityKeeper.InitializeAndSeal(ctx)
 	}
 

--- a/module/app/config.go
+++ b/module/app/config.go
@@ -67,6 +67,7 @@ func NewConfigFromFlags() simulation.Config {
 		InitialBlockHeight: FlagInitialBlockHeightValue,
 		NumBlocks:          FlagNumBlocksValue,
 		BlockSize:          FlagBlockSizeValue,
+		ChainID:            "",
 		Lean:               FlagLeanValue,
 		Commit:             FlagCommitValue,
 		OnOperation:        FlagOnOperationValue,

--- a/module/app/export.go
+++ b/module/app/export.go
@@ -3,6 +3,7 @@ package app
 import (
 	"encoding/json"
 	"log"
+	"time"
 
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -10,6 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	"github.com/tendermint/tendermint/proto/tendermint/version"
 )
 
 // ExportAppStateAndValidators exports the state of the application for a genesis
@@ -18,7 +20,31 @@ func (app *Gravity) ExportAppStateAndValidators(
 	forZeroHeight bool, jailWhiteList []string,
 ) (servertypes.ExportedApp, error) {
 
-	ctx := app.NewContext(true, tmproto.Header{Height: app.LastBlockHeight()})
+	ctx := app.NewContext(true, tmproto.Header{
+		Version: version.Consensus{
+			Block: 0,
+			App:   0,
+		},
+		ChainID: "",
+		Height:  app.LastBlockHeight(),
+		Time:    time.Time{},
+		LastBlockId: tmproto.BlockID{
+			Hash: []byte{},
+			PartSetHeader: tmproto.PartSetHeader{
+				Total: 0,
+				Hash:  []byte{},
+			},
+		},
+		LastCommitHash:     []byte{},
+		DataHash:           []byte{},
+		ValidatorsHash:     []byte{},
+		NextValidatorsHash: []byte{},
+		ConsensusHash:      []byte{},
+		AppHash:            []byte{},
+		LastResultsHash:    []byte{},
+		EvidenceHash:       []byte{},
+		ProposerAddress:    []byte{},
+	})
 
 	height := app.LastBlockHeight() + 1
 	if forZeroHeight {

--- a/module/app/sim_test.go
+++ b/module/app/sim_test.go
@@ -87,6 +87,7 @@ func TestFullAppSimulation(t *testing.T) {
 	}
 }
 
+//nolint: exhaustivestruct
 func TestAppImportExport(t *testing.T) {
 	config, db, dir, logger, skip, err := SetupSimulation("leveldb-app-sim", "Simulation")
 	if skip {
@@ -184,6 +185,7 @@ func TestAppImportExport(t *testing.T) {
 	}
 }
 
+//nolint: exhaustivestruct
 func TestAppSimulationAfterImport(t *testing.T) {
 	config, db, dir, logger, skip, err := simapp.SetupSimulation("leveldb-app-sim", "Simulation")
 	if skip {

--- a/module/app/state.go
+++ b/module/app/state.go
@@ -117,6 +117,9 @@ func AppStateRandomizedFn(
 		InitialStake: initialStake,
 		NumBonded:    numInitiallyBonded,
 		GenTimestamp: genesisTimestamp,
+		UnbondTime:   0,
+		ParamChanges: []simtypes.ParamChange{},
+		Contents:     []simtypes.WeightedProposalContent{},
 	}
 
 	simManager.GenerateGenesisStates(simState)
@@ -173,7 +176,12 @@ func StateFromGenesisFileFn(r io.Reader, cdc codec.JSONMarshaler, genesisFile st
 		}
 
 		// create simulator accounts
-		simAcc := simtypes.Account{PrivKey: privKey, PubKey: privKey.PubKey(), Address: a.GetAddress()}
+		simAcc := simtypes.Account{
+			PrivKey: privKey,
+			PubKey:  privKey.PubKey(),
+			Address: a.GetAddress(),
+			ConsKey: nil,
+		}
 		newAccs[i] = simAcc
 	}
 

--- a/module/app/utils.go
+++ b/module/app/utils.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
+	"time"
 
 	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
@@ -21,7 +23,23 @@ import (
 // Returns error on an invalid db intantiation or temp dir creation.
 func SetupSimulation(dirPrefix, dbName string) (simtypes.Config, dbm.DB, string, log.Logger, bool, error) {
 	if !FlagEnabledValue {
-		return simtypes.Config{}, nil, "", nil, true, nil
+		return simtypes.Config{
+			GenesisFile:        "",
+			ParamsFile:         "",
+			ExportParamsPath:   "",
+			ExportParamsHeight: 0,
+			ExportStatePath:    "",
+			ExportStatsPath:    "",
+			Seed:               0,
+			InitialBlockHeight: 0,
+			NumBlocks:          0,
+			BlockSize:          0,
+			ChainID:            "",
+			Lean:               false,
+			Commit:             false,
+			OnOperation:        false,
+			AllInvariants:      false,
+		}, nil, "", nil, true, nil
 	}
 
 	config := NewConfigFromFlags()
@@ -51,8 +69,17 @@ func SetupSimulation(dirPrefix, dbName string) (simtypes.Config, dbm.DB, string,
 // and returns all the modules weighted operations
 func SimulationOperations(app Gravity, cdc codec.JSONMarshaler, config simtypes.Config) []simtypes.WeightedOperation {
 	simState := module.SimulationState{
-		AppParams: make(simtypes.AppParams),
-		Cdc:       cdc,
+		AppParams:    make(simtypes.AppParams),
+		Cdc:          cdc,
+		Rand:         &rand.Rand{},
+		GenState:     map[string]json.RawMessage{},
+		Accounts:     []simtypes.Account{},
+		InitialStake: 0,
+		NumBonded:    0,
+		GenTimestamp: time.Time{},
+		UnbondTime:   0,
+		ParamChanges: []simtypes.ParamChange{},
+		Contents:     []simtypes.WeightedProposalContent{},
 	}
 
 	if config.ParamsFile != "" {

--- a/module/cmd/gravity/cmd/eth_keys.go
+++ b/module/cmd/gravity/cmd/eth_keys.go
@@ -21,6 +21,7 @@ const flagPassphrase = "passphrase"
 // Commands registers a sub-tree of commands to interact with
 // local private key storage.
 func Commands(defaultNodeHome string) *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "eth_keys",
 		Short: "Manage your application's ethereum keys",
@@ -46,6 +47,7 @@ The keyring supports the following backends:
 
 // AddKeyCommand defines a keys command to generate a key
 func AddKeyCommand() *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add an encrypted private ethereum key",

--- a/module/cmd/gravity/cmd/genaccounts.go
+++ b/module/cmd/gravity/cmd/genaccounts.go
@@ -29,6 +29,7 @@ const (
 
 // AddGenesisAccountCmd returns add-genesis-account cobra Command.
 func AddGenesisAccountCmd(defaultNodeHome string) *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "add-genesis-account [address_or_key_name] [coin][,[coin]]",
 		Short: "Add a genesis account to genesis.json",

--- a/module/cmd/gravity/cmd/genaccounts_test.go
+++ b/module/cmd/gravity/cmd/genaccounts_test.go
@@ -22,6 +22,7 @@ import (
 
 var testMbm = module.NewBasicManager(genutil.AppModuleBasic{})
 
+//nolint: exhaustivestruct
 func TestAddGenesisAccountCmd(t *testing.T) {
 	_, _, addr1 := testdata.KeyTestPubAddr()
 	tests := []struct {

--- a/module/cmd/gravity/cmd/gentx.go
+++ b/module/cmd/gravity/cmd/gentx.go
@@ -42,6 +42,7 @@ func GenTxCmd(mbm module.BasicManager, txEncCfg client.TxEncodingConfig, genBalI
 	ipDefault, _ := server.ExternalIP()
 	fsCreateValidator, defaultsDesc := cli.CreateValidatorMsgFlagSet(ipDefault)
 
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "gentx [key_name] [amount] [eth-address] [orchestrator-address]",
 		Short: "Generate a genesis tx carrying a self delegation, oracle key delegation and orchestrator key delegation",
@@ -281,6 +282,7 @@ const flagGenTxDir = "gentx-dir"
 
 // CollectGenTxsCmd - return the cobra command to collect genesis transactions
 func CollectGenTxsCmd(genBalIterator types.GenesisBalancesIterator, defaultNodeHome string) *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "collect-gentxs",
 		Short: "Collect genesis txs and output a genesis.json file",

--- a/module/cmd/gravity/cmd/root.go
+++ b/module/cmd/gravity/cmd/root.go
@@ -39,6 +39,7 @@ import (
 // main function.
 func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 	encodingConfig := app.MakeEncodingConfig()
+	//nolint: exhaustivestruct
 	initClientCtx := client.Context{}.
 		WithJSONMarshaler(encodingConfig.Marshaler).
 		WithInterfaceRegistry(encodingConfig.InterfaceRegistry).
@@ -49,6 +50,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		WithBroadcastMode(flags.BroadcastBlock).
 		WithHomeDir(app.DefaultNodeHome)
 
+	//nolint: exhaustivestruct
 	rootCmd := &cobra.Command{
 		Use:   "gravity",
 		Short: "Stargate Gravity App",
@@ -76,6 +78,7 @@ func Execute(rootCmd *cobra.Command) error {
 	// https://github.com/spf13/cobra/pull/1118.
 	srvCtx := server.NewDefaultContext()
 	ctx := context.Background()
+	//nolint: exhaustivestruct
 	ctx = context.WithValue(ctx, client.ClientContextKey, &client.Context{})
 	ctx = context.WithValue(ctx, server.ServerContextKey, srvCtx)
 
@@ -117,6 +120,7 @@ func addModuleInitFlags(startCmd *cobra.Command) {
 }
 
 func queryCommand() *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:                        "query",
 		Aliases:                    []string{"q"},
@@ -141,6 +145,7 @@ func queryCommand() *cobra.Command {
 }
 
 func txCommand() *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:                        "tx",
 		Short:                      "Transactions subcommands",

--- a/module/cmd/gravity/cmd/testnet.go
+++ b/module/cmd/gravity/cmd/testnet.go
@@ -9,12 +9,14 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"time"
 
 	crypto "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/spf13/cobra"
 	tmconfig "github.com/tendermint/tendermint/config"
 	tmos "github.com/tendermint/tendermint/libs/os"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
 
@@ -44,6 +46,7 @@ var (
 
 // get cmd to initialize all files for tendermint testnet and application
 func testnetCmd(mbm module.BasicManager, genBalIterator banktypes.GenesisBalancesIterator) *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "testnet",
 		Short: "Initialize files for a simapp testnet",
@@ -295,9 +298,30 @@ func initGenFiles(
 	}
 
 	genDoc := types.GenesisDoc{
-		ChainID:    chainID,
-		AppState:   appGenStateJSON,
+		GenesisTime:   time.Time{},
+		ChainID:       chainID,
+		InitialHeight: 0,
+		ConsensusParams: &tmproto.ConsensusParams{
+			Block: tmproto.BlockParams{
+				MaxBytes:   0,
+				MaxGas:     0,
+				TimeIotaMs: 0,
+			},
+			Evidence: tmproto.EvidenceParams{
+				MaxAgeNumBlocks: 0,
+				MaxAgeDuration:  0,
+				MaxBytes:        0,
+			},
+			Validator: tmproto.ValidatorParams{
+				PubKeyTypes: []string{},
+			},
+			Version: tmproto.VersionParams{
+				AppVersion: 0,
+			},
+		},
 		Validators: nil,
+		AppHash:    []byte{},
+		AppState:   appGenStateJSON,
 	}
 
 	// generate empty genesis files for each validator and save

--- a/module/x/gravity/abci_test.go
+++ b/module/x/gravity/abci_test.go
@@ -177,6 +177,7 @@ func TestBatchSlashing(t *testing.T) {
 	// First store a batch
 	batch := &types.OutgoingTxBatch{
 		BatchNonce:    1,
+		BatchTimeout:  0,
 		Transactions:  []*types.OutgoingTransferTx{},
 		TokenContract: keeper.TokenContractAddrs[0],
 		Block:         uint64(ctx.BlockHeight() - int64(params.SignedBatchesWindow+1)),
@@ -192,7 +193,14 @@ func TestBatchSlashing(t *testing.T) {
 			// don't sign with 2nd validator. set val bond height > batch block height
 			validator := input.StakingKeeper.Validator(ctx, keeper.ValAddrs[i])
 			valConsAddr, _ := validator.GetConsAddr()
-			valSigningInfo := slashingtypes.ValidatorSigningInfo{StartHeight: int64(batch.Block + 1)}
+			valSigningInfo := slashingtypes.ValidatorSigningInfo{
+				Address:             "",
+				StartHeight:         int64(batch.Block + 1),
+				IndexOffset:         0,
+				JailedUntil:         time.Time{},
+				Tombstoned:          false,
+				MissedBlocksCounter: 0,
+			}
 			input.SlashingKeeper.SetValidatorSigningInfo(ctx, valConsAddr, valSigningInfo)
 			continue
 		}
@@ -201,6 +209,7 @@ func TestBatchSlashing(t *testing.T) {
 			TokenContract: keeper.TokenContractAddrs[0],
 			EthSigner:     keeper.EthAddrs[i].String(),
 			Orchestrator:  val.String(),
+			Signature:     "",
 		})
 	}
 

--- a/module/x/gravity/client/cli/query.go
+++ b/module/x/gravity/client/cli/query.go
@@ -11,6 +11,7 @@ import (
 )
 
 func GetQueryCmd() *cobra.Command {
+	//nolint: exhaustivestruct
 	gravityQueryCmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      "Querying commands for the gravity module",
@@ -36,6 +37,7 @@ func GetQueryCmd() *cobra.Command {
 }
 
 func QueryObserved() *cobra.Command {
+	//nolint: exhaustivestruct
 	testingTxCmd := &cobra.Command{
 		Use:                        "observed",
 		Short:                      "observed ETH events",
@@ -53,6 +55,7 @@ func QueryObserved() *cobra.Command {
 	return testingTxCmd
 }
 func QueryApproved() *cobra.Command {
+	//nolint: exhaustivestruct
 	testingTxCmd := &cobra.Command{
 		Use:                        "approved",
 		Short:                      "approved cosmos operation",
@@ -70,6 +73,7 @@ func QueryApproved() *cobra.Command {
 }
 
 func CmdGetCurrentValset() *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "current-valset",
 		Short: "Query current valset",
@@ -93,6 +97,7 @@ func CmdGetCurrentValset() *cobra.Command {
 }
 
 func CmdGetValsetRequest() *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "valset-request [nonce]",
 		Short: "Get requested valset with a particular nonce",
@@ -123,6 +128,7 @@ func CmdGetValsetRequest() *cobra.Command {
 }
 
 func CmdGetValsetConfirm() *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "valset-confirm [nonce] [bech32 validator address]",
 		Short: "Get valset confirmation with a particular nonce from a particular validator",
@@ -154,6 +160,7 @@ func CmdGetValsetConfirm() *cobra.Command {
 }
 
 func CmdGetPendingValsetRequest() *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "pending-valset-request [bech32 validator address]",
 		Short: "Get the latest valset request which has not been signed by a particular validator",
@@ -179,6 +186,7 @@ func CmdGetPendingValsetRequest() *cobra.Command {
 }
 
 func CmdGetPendingOutgoingTXBatchRequest() *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "pending-batch-request [bech32 validator address]",
 		Short: "Get the latest outgoing TX batch request which has not been signed by a particular validator",

--- a/module/x/gravity/client/cli/tx.go
+++ b/module/x/gravity/client/cli/tx.go
@@ -18,6 +18,7 @@ import (
 )
 
 func GetTxCmd(storeKey string) *cobra.Command {
+	//nolint: exhaustivestruct
 	gravityTxCmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      "Gravity transaction subcommands",
@@ -37,6 +38,7 @@ func GetTxCmd(storeKey string) *cobra.Command {
 }
 
 func GetUnsafeTestingCmd() *cobra.Command {
+	//nolint: exhaustivestruct
 	testingTxCmd := &cobra.Command{
 		Use:                        "unsafe_testing",
 		Short:                      "helpers for testing. not going into production",
@@ -53,6 +55,7 @@ func GetUnsafeTestingCmd() *cobra.Command {
 }
 
 func CmdUnsafeETHPrivKey() *cobra.Command {
+	//nolint: exhaustivestruct
 	return &cobra.Command{
 		Use:   "gen-eth-key",
 		Short: "Generate and print a new ecdsa key",
@@ -69,6 +72,7 @@ func CmdUnsafeETHPrivKey() *cobra.Command {
 }
 
 func CmdUnsafeETHAddr() *cobra.Command {
+	//nolint: exhaustivestruct
 	return &cobra.Command{
 		Use:   "eth-address",
 		Short: "Print address for an ECDSA eth key",
@@ -93,6 +97,7 @@ func CmdUnsafeETHAddr() *cobra.Command {
 }
 
 func CmdSendToEth() *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "send-to-eth [eth-dest] [amount] [bridge-fee]",
 		Short: "Adds a new entry to the transaction pool to withdraw an amount from the Ethereum bridge contract",
@@ -136,6 +141,7 @@ func CmdSendToEth() *cobra.Command {
 }
 
 func CmdRequestBatch() *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "build-batch [token_contract_address]",
 		Short: "Build a new batch on the cosmos side for pooled withdrawal transactions",
@@ -164,6 +170,7 @@ func CmdRequestBatch() *cobra.Command {
 }
 
 func CmdSetOrchestratorAddress() *cobra.Command {
+	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
 		Use:   "set-orchestrator-address [validator-address] [orchestrator-address] [ethereum-address]",
 		Short: "Allows validators to delegate their voting responsibilities to a given key.",

--- a/module/x/gravity/cosmos-originated_test.go
+++ b/module/x/gravity/cosmos-originated_test.go
@@ -73,12 +73,13 @@ func addDenomToERC20Relation(tv *testingVars) {
 	)
 
 	ethClaim := types.MsgERC20DeployedClaim{
+		EventNonce:    myNonce,
+		BlockHeight:   0,
 		CosmosDenom:   tv.denom,
 		TokenContract: tv.erc20,
 		Name:          "atom",
 		Symbol:        "atom",
 		Decimals:      6,
-		EventNonce:    myNonce,
 		Orchestrator:  tv.myOrchestratorAddr.String(),
 	}
 
@@ -160,6 +161,7 @@ func acceptDepositEvent(tv *testingVars) {
 
 	ethClaim := types.MsgSendToCosmosClaim{
 		EventNonce:     myNonce,
+		BlockHeight:    0,
 		TokenContract:  myErc20.Contract,
 		Amount:         myErc20.Amount,
 		EthereumSender: anyETHAddr,

--- a/module/x/gravity/handler_test.go
+++ b/module/x/gravity/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/althea-net/cosmos-gravity-bridge/module/x/gravity/types"
 )
 
+//nolint: exhaustivestruct
 func TestHandleMsgSendToEth(t *testing.T) {
 	var (
 		userCosmosAddr, _               = sdk.AccAddressFromBech32("cosmos1990z7dqsvh8gthw9pa5sn4wuy2xrsd80mg5z6y")
@@ -75,6 +76,7 @@ func TestHandleMsgSendToEth(t *testing.T) {
 	assert.Equal(t, sdk.Coins{sdk.NewCoin(denom, finalAmount3)}, balance4)
 }
 
+//nolint: exhaustivestruct
 func TestMsgSendToCosmosClaimSingleValidator(t *testing.T) {
 	var (
 		myOrchestratorAddr sdk.AccAddress = make([]byte, sdk.AddrLen)
@@ -170,6 +172,7 @@ func TestMsgSendToCosmosClaimSingleValidator(t *testing.T) {
 	assert.Equal(t, sdk.Coins{sdk.NewCoin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", amountB)}, balance)
 }
 
+//nolint: exhaustivestruct
 func TestMsgSendToCosmosClaimsMultiValidator(t *testing.T) {
 	var (
 		orchestratorAddr1, _ = sdk.AccAddressFromBech32("cosmos1dg55rtevlfxh46w88yjpdd08sqhh5cc3xhkcej")
@@ -261,6 +264,7 @@ func TestMsgSendToCosmosClaimsMultiValidator(t *testing.T) {
 	assert.Equal(t, sdk.Coins{sdk.NewInt64Coin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", 12)}, balance3)
 }
 
+//nolint: exhaustivestruct
 func TestMsgSetOrchestratorAddresses(t *testing.T) {
 	var (
 		ethAddress                    = "0xb462864E395d88d6bc7C5dd5F3F5eb4cc2599255"

--- a/module/x/gravity/keeper/attestation.go
+++ b/module/x/gravity/keeper/attestation.go
@@ -39,6 +39,7 @@ func (k Keeper) Attest(
 	if att == nil {
 		att = &types.Attestation{
 			Observed: false,
+			Votes:    []string{},
 			Height:   uint64(ctx.BlockHeight()),
 			Claim:    anyClaim,
 		}
@@ -198,7 +199,18 @@ func (k Keeper) IterateAttestaions(ctx sdk.Context, cb func([]byte, types.Attest
 	defer iter.Close()
 
 	for ; iter.Valid(); iter.Next() {
-		att := types.Attestation{}
+		att := types.Attestation{
+			Observed: false,
+			Votes:    []string{},
+			Height:   0,
+			Claim: &codectypes.Any{
+				TypeUrl:              "",
+				Value:                []byte{},
+				XXX_NoUnkeyedLiteral: struct{}{},
+				XXX_unrecognized:     []byte{},
+				XXX_sizecache:        0,
+			},
+		}
 		k.cdc.MustUnmarshalBinaryBare(iter.Value(), &att)
 		// cb returns true to stop early
 		if cb(iter.Key(), att) {
@@ -230,7 +242,10 @@ func (k Keeper) GetLastObservedEthereumBlockHeight(ctx sdk.Context) types.LastOb
 			EthereumBlockHeight: 0,
 		}
 	}
-	height := types.LastObservedEthereumBlockHeight{}
+	height := types.LastObservedEthereumBlockHeight{
+		CosmosBlockHeight:   0,
+		EthereumBlockHeight: 0,
+	}
 	k.cdc.MustUnmarshalBinaryBare(bytes, &height)
 	return height
 }
@@ -256,7 +271,13 @@ func (k Keeper) GetLastObservedValset(ctx sdk.Context) *types.Valset {
 	if len(bytes) == 0 {
 		return nil
 	}
-	valset := types.Valset{}
+	valset := types.Valset{
+		Nonce:        0,
+		Members:      []*types.BridgeValidator{},
+		Height:       0,
+		RewardAmount: sdk.Int{},
+		RewardToken:  "",
+	}
 	k.cdc.MustUnmarshalBinaryBare(bytes, &valset)
 	return &valset
 }

--- a/module/x/gravity/keeper/attestation_handler.go
+++ b/module/x/gravity/keeper/attestation_handler.go
@@ -120,6 +120,7 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation, claim
 		a.keeper.SetLastObservedValset(ctx, types.Valset{
 			Nonce:        claim.ValsetNonce,
 			Members:      claim.Members,
+			Height:       0,
 			RewardAmount: claim.RewardAmount,
 			RewardToken:  claim.RewardToken,
 		})

--- a/module/x/gravity/keeper/batch.go
+++ b/module/x/gravity/keeper/batch.go
@@ -56,6 +56,7 @@ func (k Keeper) BuildOutgoingTXBatch(
 		BatchTimeout:  k.getBatchTimeoutHeight(ctx),
 		Transactions:  selectedTx,
 		TokenContract: contractAddress,
+		Block:         0,
 	}
 	k.StoreBatch(ctx, batch)
 

--- a/module/x/gravity/keeper/batch_test.go
+++ b/module/x/gravity/keeper/batch_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/althea-net/cosmos-gravity-bridge/module/x/gravity/types"
 )
 
+//nolint: exhaustivestruct
 func TestBatches(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -194,6 +195,7 @@ func TestBatches(t *testing.T) {
 
 // tests that batches work with large token amounts, mostly a duplicate of the above
 // tests but using much bigger numbers
+//nolint: exhaustivestruct
 func TestBatchesFullCoins(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -379,6 +381,7 @@ func TestBatchesFullCoins(t *testing.T) {
 
 // TestManyBatches handles test cases around batch execution, specifically executing multiple batches
 // out of sequential order, which is exactly what happens on the
+//nolint: exhaustivestruct
 func TestManyBatches(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -455,6 +458,7 @@ func TestManyBatches(t *testing.T) {
 	}
 }
 
+//nolint: exhaustivestruct
 func TestPoolTxRefund(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context

--- a/module/x/gravity/keeper/evidence_test.go
+++ b/module/x/gravity/keeper/evidence_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint: exhaustivestruct
 func TestSubmitBadSignatureEvidenceBatchExists(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -59,6 +60,7 @@ func TestSubmitBadSignatureEvidenceBatchExists(t *testing.T) {
 	require.EqualError(t, err, "Checkpoint exists, cannot slash: invalid")
 }
 
+//nolint: exhaustivestruct
 func TestSubmitBadSignatureEvidenceValsetExists(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -76,6 +78,7 @@ func TestSubmitBadSignatureEvidenceValsetExists(t *testing.T) {
 	require.EqualError(t, err, "Checkpoint exists, cannot slash: invalid")
 }
 
+//nolint: exhaustivestruct
 func TestSubmitBadSignatureEvidenceLogicCallExists(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -97,6 +100,7 @@ func TestSubmitBadSignatureEvidenceLogicCallExists(t *testing.T) {
 	require.EqualError(t, err, "Checkpoint exists, cannot slash: invalid")
 }
 
+//nolint: exhaustivestruct
 func TestSubmitBadSignatureEvidenceSlash(t *testing.T) {
 	input, ctx := SetupFiveValChain(t)
 

--- a/module/x/gravity/keeper/grpc_query.go
+++ b/module/x/gravity/keeper/grpc_query.go
@@ -5,11 +5,20 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
 	"github.com/althea-net/cosmos-gravity-bridge/module/x/gravity/types"
 )
 
-var _ types.QueryServer = Keeper{}
+var _ types.QueryServer = Keeper{
+	StakingKeeper:      nil,
+	storeKey:           nil,
+	paramSpace:         paramstypes.Subspace{},
+	cdc:                nil,
+	bankKeeper:         nil,
+	SlashingKeeper:     nil,
+	AttestationHandler: nil,
+}
 
 // Params queries the params of the gravity module
 func (k Keeper) Params(c context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {

--- a/module/x/gravity/keeper/hooks.go
+++ b/module/x/gravity/keeper/hooks.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
@@ -10,7 +11,17 @@ type Hooks struct {
 	k Keeper
 }
 
-var _ stakingtypes.StakingHooks = Hooks{}
+var _ stakingtypes.StakingHooks = Hooks{
+	k: Keeper{
+		StakingKeeper:      nil,
+		storeKey:           nil,
+		paramSpace:         paramstypes.Subspace{},
+		cdc:                nil,
+		bankKeeper:         nil,
+		SlashingKeeper:     nil,
+		AttestationHandler: nil,
+	},
+}
 
 // Create new gravity hooks
 func (k Keeper) Hooks() Hooks { return Hooks{k} }

--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -37,12 +37,13 @@ func NewKeeper(cdc codec.BinaryMarshaler, storeKey sdk.StoreKey, paramSpace para
 	}
 
 	k := Keeper{
-		cdc:            cdc,
-		paramSpace:     paramSpace,
-		storeKey:       storeKey,
-		StakingKeeper:  stakingKeeper,
-		bankKeeper:     bankKeeper,
-		SlashingKeeper: slashingKeeper,
+		StakingKeeper:      stakingKeeper,
+		storeKey:           storeKey,
+		paramSpace:         paramSpace,
+		cdc:                cdc,
+		bankKeeper:         bankKeeper,
+		SlashingKeeper:     slashingKeeper,
+		AttestationHandler: nil,
 	}
 	k.AttestationHandler = AttestationHandler{
 		keeper:     k,
@@ -274,7 +275,9 @@ func prefixRange(prefix []byte) ([]byte, []byte) {
 // DeserializeValidatorIterator returns validators from the validator iterator.
 // Adding here in gravity keeper as cdc is not available inside endblocker.
 func (k Keeper) DeserializeValidatorIterator(vals []byte) stakingtypes.ValAddresses {
-	validators := stakingtypes.ValAddresses{}
+	validators := stakingtypes.ValAddresses{
+		Addresses: []string{},
+	}
 	k.cdc.MustUnmarshalBinaryBare(vals, &validators)
 	return validators
 }

--- a/module/x/gravity/keeper/keeper_batch.go
+++ b/module/x/gravity/keeper/keeper_batch.go
@@ -18,7 +18,13 @@ func (k Keeper) GetBatchConfirm(ctx sdk.Context, nonce uint64, tokenContract str
 	if entity == nil {
 		return nil
 	}
-	confirm := types.MsgConfirmBatch{}
+	confirm := types.MsgConfirmBatch{
+		Nonce:         nonce,
+		TokenContract: tokenContract,
+		EthSigner:     "",
+		Orchestrator:  "",
+		Signature:     "",
+	}
 	k.cdc.MustUnmarshalBinaryBare(entity, &confirm)
 	return &confirm
 }
@@ -45,7 +51,13 @@ func (k Keeper) IterateBatchConfirmByNonceAndTokenContract(ctx sdk.Context, nonc
 	defer iter.Close()
 
 	for ; iter.Valid(); iter.Next() {
-		confirm := types.MsgConfirmBatch{}
+		confirm := types.MsgConfirmBatch{
+			Nonce:         nonce,
+			TokenContract: tokenContract,
+			EthSigner:     "",
+			Orchestrator:  "",
+			Signature:     "",
+		}
 		k.cdc.MustUnmarshalBinaryBare(iter.Value(), &confirm)
 		// cb returns true to stop early
 		if cb(iter.Key(), confirm) {

--- a/module/x/gravity/keeper/keeper_delegate_key.go
+++ b/module/x/gravity/keeper/keeper_delegate_key.go
@@ -1,6 +1,9 @@
 package keeper
 
 import (
+	"time"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
@@ -22,11 +25,73 @@ func (k Keeper) GetOrchestratorValidator(ctx sdk.Context, orch sdk.AccAddress) (
 	store := ctx.KVStore(k.storeKey)
 	valAddr := store.Get(types.GetOrchestratorAddressKey(orch))
 	if valAddr == nil {
-		return stakingtypes.Validator{}, false
+		return stakingtypes.Validator{
+			OperatorAddress: "",
+			ConsensusPubkey: &codectypes.Any{
+				TypeUrl:              "",
+				Value:                []byte{},
+				XXX_NoUnkeyedLiteral: struct{}{},
+				XXX_unrecognized:     []byte{},
+				XXX_sizecache:        0,
+			},
+			Jailed:          false,
+			Status:          0,
+			Tokens:          sdk.Int{},
+			DelegatorShares: sdk.Dec{},
+			Description: stakingtypes.Description{
+				Moniker:         "",
+				Identity:        "",
+				Website:         "",
+				SecurityContact: "",
+				Details:         "",
+			},
+			UnbondingHeight: 0,
+			UnbondingTime:   time.Time{},
+			Commission: stakingtypes.Commission{
+				CommissionRates: stakingtypes.CommissionRates{
+					Rate:          sdk.Dec{},
+					MaxRate:       sdk.Dec{},
+					MaxChangeRate: sdk.Dec{},
+				},
+				UpdateTime: time.Time{},
+			},
+			MinSelfDelegation: sdk.Int{},
+		}, false
 	}
 	validator, found = k.StakingKeeper.GetValidator(ctx, valAddr)
 	if !found {
-		return stakingtypes.Validator{}, false
+		return stakingtypes.Validator{
+			OperatorAddress: "",
+			ConsensusPubkey: &codectypes.Any{
+				TypeUrl:              "",
+				Value:                []byte{},
+				XXX_NoUnkeyedLiteral: struct{}{},
+				XXX_unrecognized:     []byte{},
+				XXX_sizecache:        0,
+			},
+			Jailed:          false,
+			Status:          0,
+			Tokens:          sdk.Int{},
+			DelegatorShares: sdk.Dec{},
+			Description: stakingtypes.Description{
+				Moniker:         "",
+				Identity:        "",
+				Website:         "",
+				SecurityContact: "",
+				Details:         "",
+			},
+			UnbondingHeight: 0,
+			UnbondingTime:   time.Time{},
+			Commission: stakingtypes.Commission{
+				CommissionRates: stakingtypes.CommissionRates{
+					Rate:          sdk.Dec{},
+					MaxRate:       sdk.Dec{},
+					MaxChangeRate: sdk.Dec{},
+				},
+				UpdateTime: time.Time{},
+			},
+			MinSelfDelegation: sdk.Int{},
+		}, false
 	}
 
 	return validator, true
@@ -59,11 +124,73 @@ func (k Keeper) GetValidatorByEthAddress(ctx sdk.Context, ethAddr string) (valid
 	store := ctx.KVStore(k.storeKey)
 	valAddr := store.Get(types.GetValidatorByEthAddressKey(ethAddr))
 	if valAddr == nil {
-		return stakingtypes.Validator{}, false
+		return stakingtypes.Validator{
+			OperatorAddress: "",
+			ConsensusPubkey: &codectypes.Any{
+				TypeUrl:              "",
+				Value:                []byte{},
+				XXX_NoUnkeyedLiteral: struct{}{},
+				XXX_unrecognized:     []byte{},
+				XXX_sizecache:        0,
+			},
+			Jailed:          false,
+			Status:          0,
+			Tokens:          sdk.Int{},
+			DelegatorShares: sdk.Dec{},
+			Description: stakingtypes.Description{
+				Moniker:         "",
+				Identity:        "",
+				Website:         "",
+				SecurityContact: "",
+				Details:         "",
+			},
+			UnbondingHeight: 0,
+			UnbondingTime:   time.Time{},
+			Commission: stakingtypes.Commission{
+				CommissionRates: stakingtypes.CommissionRates{
+					Rate:          sdk.Dec{},
+					MaxRate:       sdk.Dec{},
+					MaxChangeRate: sdk.Dec{},
+				},
+				UpdateTime: time.Time{},
+			},
+			MinSelfDelegation: sdk.Int{},
+		}, false
 	}
 	validator, found = k.StakingKeeper.GetValidator(ctx, valAddr)
 	if !found {
-		return stakingtypes.Validator{}, false
+		return stakingtypes.Validator{
+			OperatorAddress: "",
+			ConsensusPubkey: &codectypes.Any{
+				TypeUrl:              "",
+				Value:                []byte{},
+				XXX_NoUnkeyedLiteral: struct{}{},
+				XXX_unrecognized:     []byte{},
+				XXX_sizecache:        0,
+			},
+			Jailed:          false,
+			Status:          0,
+			Tokens:          sdk.Int{},
+			DelegatorShares: sdk.Dec{},
+			Description: stakingtypes.Description{
+				Moniker:         "",
+				Identity:        "",
+				Website:         "",
+				SecurityContact: "",
+				Details:         "",
+			},
+			UnbondingHeight: 0,
+			UnbondingTime:   time.Time{},
+			Commission: stakingtypes.Commission{
+				CommissionRates: stakingtypes.CommissionRates{
+					Rate:          sdk.Dec{},
+					MaxRate:       sdk.Dec{},
+					MaxChangeRate: sdk.Dec{},
+				},
+				UpdateTime: time.Time{},
+			},
+			MinSelfDelegation: sdk.Int{},
+		}, false
 	}
 
 	return validator, true

--- a/module/x/gravity/keeper/keeper_logic_call.go
+++ b/module/x/gravity/keeper/keeper_logic_call.go
@@ -17,7 +17,16 @@ import (
 // GetOutgoingLogicCall gets an outgoing logic call
 func (k Keeper) GetOutgoingLogicCall(ctx sdk.Context, invalidationID []byte, invalidationNonce uint64) *types.OutgoingLogicCall {
 	store := ctx.KVStore(k.storeKey)
-	call := types.OutgoingLogicCall{}
+	call := types.OutgoingLogicCall{
+		Transfers:            []*types.ERC20Token{},
+		Fees:                 []*types.ERC20Token{},
+		LogicContractAddress: "",
+		Payload:              []byte{},
+		Timeout:              0,
+		InvalidationId:       invalidationID,
+		InvalidationNonce:    invalidationNonce,
+		Block:                0,
+	}
 	k.cdc.MustUnmarshalBinaryBare(store.Get(types.GetOutgoingLogicCallKey(invalidationID, invalidationNonce)), &call)
 	return &call
 }
@@ -110,7 +119,13 @@ func (k Keeper) GetLogicCallConfirm(ctx sdk.Context, invalidationId []byte, inva
 	if data == nil {
 		return nil
 	}
-	out := types.MsgConfirmLogicCall{}
+	out := types.MsgConfirmLogicCall{
+		InvalidationId:    "",
+		InvalidationNonce: invalidationNonce,
+		EthSigner:         "",
+		Orchestrator:      "",
+		Signature:         "",
+	}
 	k.cdc.MustUnmarshalBinaryBare(data, &out)
 	return &out
 }
@@ -135,7 +150,13 @@ func (k Keeper) IterateLogicConfirmByInvalidationIDAndNonce(
 	defer iter.Close()
 
 	for ; iter.Valid(); iter.Next() {
-		confirm := types.MsgConfirmLogicCall{}
+		confirm := types.MsgConfirmLogicCall{
+			InvalidationId:    "",
+			InvalidationNonce: invalidationNonce,
+			EthSigner:         "",
+			Orchestrator:      "",
+			Signature:         "",
+		}
 		k.cdc.MustUnmarshalBinaryBare(iter.Value(), &confirm)
 		// cb returns true to stop early
 		if cb(iter.Key(), &confirm) {

--- a/module/x/gravity/keeper/keeper_test.go
+++ b/module/x/gravity/keeper/keeper_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/althea-net/cosmos-gravity-bridge/module/x/gravity/types"
 )
 
+//nolint: exhaustivestruct
 func TestPrefixRange(t *testing.T) {
 	cases := map[string]struct {
 		src      []byte
@@ -45,6 +46,7 @@ func TestPrefixRange(t *testing.T) {
 	}
 }
 
+//nolint: exhaustivestruct
 func TestCurrentValsetNormalization(t *testing.T) {
 	specs := map[string]struct {
 		srcPowers []uint64
@@ -81,6 +83,7 @@ func TestCurrentValsetNormalization(t *testing.T) {
 	}
 }
 
+//nolint: exhaustivestruct
 func TestAttestationIterator(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -122,6 +125,7 @@ func TestAttestationIterator(t *testing.T) {
 	require.Len(t, atts, 2)
 }
 
+//nolint: exhaustivestruct
 func TestDelegateKeys(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -161,6 +165,7 @@ func TestDelegateKeys(t *testing.T) {
 
 }
 
+//nolint: exhaustivestruct
 func TestLastSlashedValsetNonce(t *testing.T) {
 	input := CreateTestEnv(t)
 	k := input.GravityKeeper

--- a/module/x/gravity/keeper/keeper_valset.go
+++ b/module/x/gravity/keeper/keeper_valset.go
@@ -283,7 +283,12 @@ func (k Keeper) GetValsetConfirm(ctx sdk.Context, nonce uint64, validator sdk.Ac
 	if entity == nil {
 		return nil
 	}
-	confirm := types.MsgValsetConfirm{}
+	confirm := types.MsgValsetConfirm{
+		Nonce:        nonce,
+		Orchestrator: "",
+		EthAddress:   "",
+		Signature:    "",
+	}
 	k.cdc.MustUnmarshalBinaryBare(entity, &confirm)
 	return &confirm
 }
@@ -309,7 +314,12 @@ func (k Keeper) GetValsetConfirms(ctx sdk.Context, nonce uint64) (confirms []*ty
 	defer iterator.Close()
 
 	for ; iterator.Valid(); iterator.Next() {
-		confirm := types.MsgValsetConfirm{}
+		confirm := types.MsgValsetConfirm{
+			Nonce:        nonce,
+			Orchestrator: "",
+			EthAddress:   "",
+			Signature:    "",
+		}
 		k.cdc.MustUnmarshalBinaryBare(iterator.Value(), &confirm)
 		confirms = append(confirms, &confirm)
 	}
@@ -324,7 +334,12 @@ func (k Keeper) IterateValsetConfirmByNonce(ctx sdk.Context, nonce uint64, cb fu
 	defer iter.Close()
 
 	for ; iter.Valid(); iter.Next() {
-		confirm := types.MsgValsetConfirm{}
+		confirm := types.MsgValsetConfirm{
+			Nonce:        nonce,
+			Orchestrator: "",
+			EthAddress:   "",
+			Signature:    "",
+		}
 		k.cdc.MustUnmarshalBinaryBare(iter.Value(), &confirm)
 		// cb returns true to stop early
 		if cb(iter.Key(), confirm) {

--- a/module/x/gravity/keeper/msg_server.go
+++ b/module/x/gravity/keeper/msg_server.go
@@ -8,6 +8,7 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/althea-net/cosmos-gravity-bridge/module/x/gravity/types"
@@ -23,7 +24,17 @@ func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{Keeper: keeper}
 }
 
-var _ types.MsgServer = msgServer{}
+var _ types.MsgServer = msgServer{
+	Keeper: Keeper{
+		StakingKeeper:      nil,
+		storeKey:           nil,
+		paramSpace:         paramstypes.Subspace{},
+		cdc:                nil,
+		bankKeeper:         nil,
+		SlashingKeeper:     nil,
+		AttestationHandler: nil,
+	},
+}
 
 func (k msgServer) SetOrchestratorAddress(c context.Context, msg *types.MsgSetOrchestratorAddress) (*types.MsgSetOrchestratorAddressResponse, error) {
 	// ensure that this passes validation, checks the key validity

--- a/module/x/gravity/keeper/querier.go
+++ b/module/x/gravity/keeper/querier.go
@@ -521,7 +521,10 @@ func queryPendingSendToEth(ctx sdk.Context, senderAddr string, k Keeper) ([]byte
 	batches := k.GetOutgoingTxBatches(ctx)
 	unbatched_tx := k.GetPoolTransactions(ctx)
 	sender_address := senderAddr
-	res := types.QueryPendingSendToEthResponse{}
+	res := types.QueryPendingSendToEthResponse{
+		TransfersInBatches: []*types.OutgoingTransferTx{},
+		UnbatchedTransfers: []*types.OutgoingTransferTx{},
+	}
 	for _, batch := range batches {
 		for _, tx := range batch.Transactions {
 			if tx.Sender == sender_address {

--- a/module/x/gravity/keeper/querier_test.go
+++ b/module/x/gravity/keeper/querier_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/althea-net/cosmos-gravity-bridge/module/x/gravity/types"
 )
 
+//nolint: exhaustivestruct
 func TestQueryValsetConfirm(t *testing.T) {
 	var (
 		nonce                                       = uint64(1)
@@ -74,6 +75,7 @@ func TestQueryValsetConfirm(t *testing.T) {
 	}
 }
 
+//nolint: exhaustivestruct
 func TestAllValsetConfirmsBynonce(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -134,6 +136,7 @@ func TestAllValsetConfirmsBynonce(t *testing.T) {
 }
 
 // TODO: Check failure modes
+//nolint: exhaustivestruct
 func TestLastValsetRequests(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -288,6 +291,7 @@ func TestLastValsetRequests(t *testing.T) {
 	}
 }
 
+//nolint: exhaustivestruct
 // TODO: check that it doesn't accidently return a valset that HAS been signed
 // Right now it is basically just testing that any valset comes back
 func TestPendingValsetRequests(t *testing.T) {
@@ -458,6 +462,7 @@ func TestPendingValsetRequests(t *testing.T) {
 	}
 }
 
+//nolint: exhaustivestruct
 // TODO: check that it actually returns a batch that has NOT been signed, not just any batch
 func TestLastPendingBatchRequest(t *testing.T) {
 	input := CreateTestEnv(t)
@@ -533,6 +538,7 @@ func TestLastPendingBatchRequest(t *testing.T) {
 	}
 }
 
+//nolint: exhaustivestruct
 func createTestBatch(t *testing.T, input TestInput) {
 	var (
 		mySender            = bytes.Repeat([]byte{1}, sdk.AddrLen)
@@ -565,6 +571,7 @@ func createTestBatch(t *testing.T, input TestInput) {
 	require.NoError(t, err)
 }
 
+//nolint: exhaustivestruct
 func TestQueryAllBatchConfirms(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -590,6 +597,7 @@ func TestQueryAllBatchConfirms(t *testing.T) {
 	assert.JSONEq(t, string(expectedJSON), string(batchConfirms), "json is equal")
 }
 
+//nolint: exhaustivestruct
 func TestQueryLogicCalls(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -646,6 +654,7 @@ func TestQueryLogicCalls(t *testing.T) {
 	require.NoError(t, err)
 }
 
+//nolint: exhaustivestruct
 func TestQueryLogicCallsConfirms(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -704,6 +713,7 @@ func TestQueryLogicCallsConfirms(t *testing.T) {
 	assert.Equal(t, len(res), 1)
 }
 
+//nolint: exhaustivestruct
 // TODO: test that it gets the correct batch, not just any batch.
 // Check with multiple nonces and tokenContracts
 func TestQueryBatch(t *testing.T) {
@@ -761,6 +771,7 @@ func TestQueryBatch(t *testing.T) {
 	assert.JSONEq(t, string(expectedJSON), string(batch), string(batch))
 }
 
+//nolint: exhaustivestruct
 func TestLastBatchesRequest(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
@@ -844,6 +855,7 @@ func TestLastBatchesRequest(t *testing.T) {
 	assert.JSONEq(t, string(expectedJSON), string(lastBatches), "json is equal")
 }
 
+//nolint: exhaustivestruct
 // tests setting and querying eth address and orchestrator addresses
 func TestQueryCurrentValset(t *testing.T) {
 	var (
@@ -862,6 +874,7 @@ func TestQueryCurrentValset(t *testing.T) {
 	assert.Equal(t, expectedValset, currentValset)
 }
 
+//nolint: exhaustivestruct
 func TestQueryERC20ToDenom(t *testing.T) {
 	var (
 		erc20 = "0xb462864E395d88d6bc7C5dd5F3F5eb4cc2599255"
@@ -883,6 +896,7 @@ func TestQueryERC20ToDenom(t *testing.T) {
 	assert.Equal(t, correctBytes, queriedDenom)
 }
 
+//nolint: exhaustivestruct
 func TestQueryDenomToERC20(t *testing.T) {
 	var (
 		erc20 = "0xb462864E395d88d6bc7C5dd5F3F5eb4cc2599255"
@@ -905,6 +919,7 @@ func TestQueryDenomToERC20(t *testing.T) {
 	assert.Equal(t, correctBytes, queriedERC20)
 }
 
+//nolint: exhaustivestruct
 func TestQueryPendingSendToEth(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context

--- a/module/x/gravity/keeper/test_common.go
+++ b/module/x/gravity/keeper/test_common.go
@@ -53,6 +53,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/althea-net/cosmos-gravity-bridge/module/x/gravity/types"
@@ -80,7 +81,10 @@ var (
 	)
 
 	// Ensure that StakingKeeperMock implements required interface
-	_ types.StakingKeeper = &StakingKeeperMock{}
+	_ types.StakingKeeper = &StakingKeeperMock{
+		BondedValidators: []stakingtypes.Validator{},
+		ValidatorPower:   map[string]int64{},
+	}
 )
 
 var (
@@ -194,12 +198,10 @@ var (
 		AverageEthereumBlockTime:     15000,
 		SlashFractionValset:          sdk.NewDecWithPrec(1, 2),
 		SlashFractionBatch:           sdk.NewDecWithPrec(1, 2),
+		SlashFractionLogicCall:       sdk.Dec{},
 		UnbondSlashingValsetsWindow:  15,
 		SlashFractionBadEthSignature: sdk.NewDecWithPrec(1, 2),
-		ValsetReward: sdk.Coin{
-			Denom:  "",
-			Amount: sdk.ZeroInt(),
-		},
+		ValsetReward:                 sdk.Coin{Denom: "", Amount: sdk.ZeroInt()},
 	}
 )
 
@@ -296,8 +298,29 @@ func CreateTestEnv(t *testing.T) TestInput {
 
 	// Create sdk.Context
 	ctx := sdk.NewContext(ms, tmproto.Header{
-		Height: 1234567,
-		Time:   time.Date(2020, time.April, 22, 12, 0, 0, 0, time.UTC),
+		Version: tmversion.Consensus{
+			Block: 0,
+			App:   0,
+		},
+		ChainID: "",
+		Height:  1234567,
+		Time:    time.Date(2020, time.April, 22, 12, 0, 0, 0, time.UTC),
+		LastBlockId: tmproto.BlockID{
+			Hash: []byte{},
+			PartSetHeader: tmproto.PartSetHeader{
+				Total: 0,
+				Hash:  []byte{},
+			},
+		},
+		LastCommitHash:     []byte{},
+		DataHash:           []byte{},
+		ValidatorsHash:     []byte{},
+		NextValidatorsHash: []byte{},
+		ConsensusHash:      []byte{},
+		AppHash:            []byte{},
+		LastResultsHash:    []byte{},
+		EvidenceHash:       []byte{},
+		ProposerAddress:    []byte{},
 	}, false, log.TestingLogger())
 
 	cdc := MakeTestCodec()
@@ -341,7 +364,10 @@ func CreateTestEnv(t *testing.T) TestInput {
 		getSubspace(paramsKeeper, banktypes.ModuleName),
 		blockedAddr,
 	)
-	bankKeeper.SetParams(ctx, banktypes.Params{DefaultSendEnabled: true})
+	bankKeeper.SetParams(ctx, banktypes.Params{
+		SendEnabled:        []*banktypes.SendEnabled{},
+		DefaultSendEnabled: true,
+	})
 
 	stakingKeeper := stakingkeeper.NewKeeper(marshaler, keyStaking, accountKeeper, bankKeeper, getSubspace(paramsKeeper, stakingtypes.ModuleName))
 	stakingKeeper.SetParams(ctx, TestingStakeParams)
@@ -375,9 +401,15 @@ func CreateTestEnv(t *testing.T) TestInput {
 	require.NotNil(t, moduleAcct)
 
 	router := baseapp.NewRouter()
-	router.AddRoute(bank.AppModule{}.Route())
-	router.AddRoute(staking.AppModule{}.Route())
-	router.AddRoute(distribution.AppModule{}.Route())
+	router.AddRoute(bank.AppModule{
+		AppModuleBasic: bank.AppModuleBasic{},
+	}.Route())
+	router.AddRoute(staking.AppModule{
+		AppModuleBasic: staking.AppModuleBasic{},
+	}.Route())
+	router.AddRoute(distribution.AppModule{
+		AppModuleBasic: distribution.AppModuleBasic{},
+	}.Route())
 
 	// Load default wasm config
 
@@ -480,7 +512,35 @@ func NewStakingKeeperMock(operators ...sdk.ValAddress) *StakingKeeperMock {
 	for _, a := range operators {
 		r.BondedValidators = append(r.BondedValidators, stakingtypes.Validator{
 			OperatorAddress: a.String(),
+			ConsensusPubkey: &codectypes.Any{
+				TypeUrl:              "",
+				Value:                []byte{},
+				XXX_NoUnkeyedLiteral: struct{}{},
+				XXX_unrecognized:     []byte{},
+				XXX_sizecache:        0,
+			},
+			Jailed:          false,
 			Status:          stakingtypes.Bonded,
+			Tokens:          InitTokens,
+			DelegatorShares: sdk.Dec{},
+			Description: stakingtypes.Description{
+				Moniker:         "",
+				Identity:        "",
+				Website:         "",
+				SecurityContact: "",
+				Details:         "",
+			},
+			UnbondingHeight: 0,
+			UnbondingTime:   time.Time{},
+			Commission: stakingtypes.Commission{
+				CommissionRates: stakingtypes.CommissionRates{
+					Rate:          sdk.Dec{},
+					MaxRate:       sdk.Dec{},
+					MaxChangeRate: sdk.Dec{},
+				},
+				UpdateTime: time.Time{},
+			},
+			MinSelfDelegation: sdk.Int{},
 		})
 		r.ValidatorPower[a.String()] = defaultTestPower
 	}
@@ -503,7 +563,35 @@ func NewStakingKeeperWeightedMock(t ...MockStakingValidatorData) *StakingKeeperM
 	for i, a := range t {
 		r.BondedValidators[i] = stakingtypes.Validator{
 			OperatorAddress: a.Operator.String(),
+			ConsensusPubkey: &codectypes.Any{
+				TypeUrl:              "",
+				Value:                []byte{},
+				XXX_NoUnkeyedLiteral: struct{}{},
+				XXX_unrecognized:     []byte{},
+				XXX_sizecache:        0,
+			},
+			Jailed:          false,
 			Status:          stakingtypes.Bonded,
+			Tokens:          InitTokens,
+			DelegatorShares: sdk.Dec{},
+			Description: stakingtypes.Description{
+				Moniker:         "",
+				Identity:        "",
+				Website:         "",
+				SecurityContact: "",
+				Details:         "",
+			},
+			UnbondingHeight: 0,
+			UnbondingTime:   time.Time{},
+			Commission: stakingtypes.Commission{
+				CommissionRates: stakingtypes.CommissionRates{
+					Rate:          sdk.Dec{},
+					MaxRate:       sdk.Dec{},
+					MaxChangeRate: sdk.Dec{},
+				},
+				UpdateTime: time.Time{},
+			},
+			MinSelfDelegation: sdk.Int{},
 		}
 		r.ValidatorPower[a.Operator.String()] = a.Power
 	}
@@ -603,7 +691,38 @@ func (s *StakingKeeperMock) GetValidator(ctx sdk.Context, addr sdk.ValAddress) (
 			return val, true
 		}
 	}
-	return stakingtypes.Validator{}, false
+	return stakingtypes.Validator{
+		OperatorAddress: "",
+		ConsensusPubkey: &codectypes.Any{
+			TypeUrl:              "",
+			Value:                []byte{},
+			XXX_NoUnkeyedLiteral: struct{}{},
+			XXX_unrecognized:     []byte{},
+			XXX_sizecache:        0,
+		},
+		Jailed:          false,
+		Status:          0,
+		Tokens:          InitTokens,
+		DelegatorShares: sdk.Dec{},
+		Description: stakingtypes.Description{
+			Moniker:         "",
+			Identity:        "",
+			Website:         "",
+			SecurityContact: "",
+			Details:         "",
+		},
+		UnbondingHeight: 0,
+		UnbondingTime:   time.Time{},
+		Commission: stakingtypes.Commission{
+			CommissionRates: stakingtypes.CommissionRates{
+				Rate:          sdk.Dec{},
+				MaxRate:       sdk.Dec{},
+				MaxChangeRate: sdk.Dec{},
+			},
+			UpdateTime: time.Time{},
+		},
+		MinSelfDelegation: sdk.Int{},
+	}, false
 }
 
 func (s *StakingKeeperMock) ValidatorQueueIterator(ctx sdk.Context, endTime time.Time, endHeight int64) sdk.Iterator {
@@ -673,7 +792,13 @@ func NewTestMsgCreateValidator(address sdk.ValAddress, pubKey ccrypto.PubKey, am
 	commission := stakingtypes.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
 	out, err := stakingtypes.NewMsgCreateValidator(
 		address, pubKey, sdk.NewCoin("stake", amt),
-		stakingtypes.Description{}, commission, sdk.OneInt(),
+		stakingtypes.Description{
+			Moniker:         "",
+			Identity:        "",
+			Website:         "",
+			SecurityContact: "",
+			Details:         "",
+		}, commission, sdk.OneInt(),
 	)
 	if err != nil {
 		panic(err)

--- a/module/x/gravity/module.go
+++ b/module/x/gravity/module.go
@@ -27,7 +27,15 @@ import (
 
 // type check to ensure the interface is properly implemented
 var (
-	_ module.AppModule      = AppModule{}
+	_ module.AppModule = AppModule{
+		AppModuleBasic: AppModuleBasic{},
+		keeper: keeper.Keeper{
+			StakingKeeper:      nil,
+			SlashingKeeper:     nil,
+			AttestationHandler: nil,
+		},
+		bankKeeper: nil,
+	}
 	_ module.AppModuleBasic = AppModuleBasic{}
 )
 

--- a/module/x/gravity/types/batch_test.go
+++ b/module/x/gravity/types/batch_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint: exhaustivestruct
 func TestOutgoingTxBatchCheckpointGold1(t *testing.T) {
 	senderAddr, err := sdk.AccAddressFromHex("527FBEE652609AB150F0AEE9D61A2F76CFC4A73E")
 	require.NoError(t, err)
@@ -49,6 +50,7 @@ func TestOutgoingTxBatchCheckpointGold1(t *testing.T) {
 	assert.Equal(t, goldHash, hex.EncodeToString(ourHash))
 }
 
+//nolint: exhaustivestruct
 func TestOutgoingLogicCallCheckpointGold1(t *testing.T) {
 	payload, err := hex.DecodeString("0x74657374696e675061796c6f6164000000000000000000000000000000000000"[2:])
 	require.NoError(t, err)

--- a/module/x/gravity/types/codec.go
+++ b/module/x/gravity/types/codec.go
@@ -14,6 +14,7 @@ func init() {
 	RegisterCodec(ModuleCdc)
 }
 
+//nolint: exhaustivestruct
 // RegisterInterfaces registers the interfaces for the proto stuff
 func RegisterInterfaces(registry types.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil),
@@ -45,6 +46,7 @@ func RegisterInterfaces(registry types.InterfaceRegistry) {
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }
 
+//nolint: exhaustivestruct
 // RegisterCodec registers concrete types on the Amino codec
 func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterInterface((*EthereumClaim)(nil), nil)

--- a/module/x/gravity/types/genesis.go
+++ b/module/x/gravity/types/genesis.go
@@ -67,7 +67,27 @@ var (
 	ParamStoreValsetRewardAmount = []byte("ValsetReward")
 
 	// Ensure that params implements the proper interface
-	_ paramtypes.ParamSet = &Params{}
+	_ paramtypes.ParamSet = &Params{
+		GravityId:                    "",
+		ContractSourceHash:           "",
+		BridgeEthereumAddress:        "",
+		BridgeChainId:                0,
+		SignedValsetsWindow:          0,
+		SignedBatchesWindow:          0,
+		SignedLogicCallsWindow:       0,
+		TargetBatchTimeout:           0,
+		AverageBlockTime:             0,
+		AverageEthereumBlockTime:     0,
+		SlashFractionValset:          sdk.Dec{},
+		SlashFractionBatch:           sdk.Dec{},
+		SlashFractionLogicCall:       sdk.Dec{},
+		UnbondSlashingValsetsWindow:  0,
+		SlashFractionBadEthSignature: sdk.Dec{},
+		ValsetReward: sdk.Coin{
+			Denom:  "",
+			Amount: sdk.Int{},
+		},
+	}
 )
 
 // ValidateBasic validates genesis state by looping through the params and
@@ -83,7 +103,18 @@ func (s GenesisState) ValidateBasic() error {
 // TODO: set some better defaults here
 func DefaultGenesisState() *GenesisState {
 	return &GenesisState{
-		Params: DefaultParams(),
+		Params:             DefaultParams(),
+		LastObservedNonce:  0,
+		Valsets:            []*Valset{},
+		ValsetConfirms:     []*MsgValsetConfirm{},
+		Batches:            []*OutgoingTxBatch{},
+		BatchConfirms:      []MsgConfirmBatch{},
+		LogicCalls:         []*OutgoingLogicCall{},
+		LogicCallConfirms:  []MsgConfirmLogicCall{},
+		Attestations:       []Attestation{},
+		DelegateKeys:       []*MsgSetOrchestratorAddress{},
+		Erc20ToDenoms:      []*ERC20ToDenom{},
+		UnbatchedTransfers: []*OutgoingTransferTx{},
 	}
 }
 
@@ -91,6 +122,9 @@ func DefaultGenesisState() *GenesisState {
 func DefaultParams() *Params {
 	return &Params{
 		GravityId:                    "defaultgravityid",
+		ContractSourceHash:           "",
+		BridgeEthereumAddress:        "",
+		BridgeChainId:                0,
 		SignedValsetsWindow:          10000,
 		SignedBatchesWindow:          10000,
 		SignedLogicCallsWindow:       10000,
@@ -100,13 +134,9 @@ func DefaultParams() *Params {
 		SlashFractionValset:          sdk.NewDec(1).Quo(sdk.NewDec(1000)),
 		SlashFractionBatch:           sdk.NewDec(1).Quo(sdk.NewDec(1000)),
 		SlashFractionLogicCall:       sdk.NewDec(1).Quo(sdk.NewDec(1000)),
-		SlashFractionBadEthSignature: sdk.NewDec(1).Quo(sdk.NewDec(1000)),
 		UnbondSlashingValsetsWindow:  10000,
-		// this coin is invalid, we use that as the 'no reward' state
-		ValsetReward: sdk.Coin{
-			Denom:  "",
-			Amount: sdk.ZeroInt(),
-		},
+		SlashFractionBadEthSignature: sdk.NewDec(1).Quo(sdk.NewDec(1000)),
+		ValsetReward:                 sdk.Coin{Denom: "", Amount: sdk.ZeroInt()},
 	}
 }
 
@@ -166,7 +196,27 @@ func (p Params) ValidateBasic() error {
 
 // ParamKeyTable for auth module
 func ParamKeyTable() paramtypes.KeyTable {
-	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
+	return paramtypes.NewKeyTable().RegisterParamSet(&Params{
+		GravityId:                    "",
+		ContractSourceHash:           "",
+		BridgeEthereumAddress:        "",
+		BridgeChainId:                0,
+		SignedValsetsWindow:          0,
+		SignedBatchesWindow:          0,
+		SignedLogicCallsWindow:       0,
+		TargetBatchTimeout:           0,
+		AverageBlockTime:             0,
+		AverageEthereumBlockTime:     0,
+		SlashFractionValset:          sdk.Dec{},
+		SlashFractionBatch:           sdk.Dec{},
+		SlashFractionLogicCall:       sdk.Dec{},
+		UnbondSlashingValsetsWindow:  0,
+		SlashFractionBadEthSignature: sdk.Dec{},
+		ValsetReward: sdk.Coin{
+			Denom:  "",
+			Amount: sdk.Int{},
+		},
+	})
 }
 
 // ParamSetPairs implements the ParamSet interface and returns all the key/value pairs

--- a/module/x/gravity/types/genesis_test.go
+++ b/module/x/gravity/types/genesis_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"testing"
 
+	types "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,14 +13,73 @@ func TestGenesisStateValidate(t *testing.T) {
 		expErr bool
 	}{
 		"default params": {src: DefaultGenesisState(), expErr: false},
-		"empty params":   {src: &GenesisState{Params: &Params{}}, expErr: true},
+		"empty params": {src: &GenesisState{
+			Params: &Params{
+				GravityId:                    "",
+				ContractSourceHash:           "",
+				BridgeEthereumAddress:        "",
+				BridgeChainId:                0,
+				SignedValsetsWindow:          0,
+				SignedBatchesWindow:          0,
+				SignedLogicCallsWindow:       0,
+				TargetBatchTimeout:           0,
+				AverageBlockTime:             0,
+				AverageEthereumBlockTime:     0,
+				SlashFractionValset:          types.Dec{},
+				SlashFractionBatch:           types.Dec{},
+				SlashFractionLogicCall:       types.Dec{},
+				UnbondSlashingValsetsWindow:  0,
+				SlashFractionBadEthSignature: types.Dec{},
+				ValsetReward: types.Coin{
+					Denom:  "",
+					Amount: types.Int{},
+				},
+			},
+			LastObservedNonce:  0,
+			Valsets:            []*Valset{},
+			ValsetConfirms:     []*MsgValsetConfirm{},
+			Batches:            []*OutgoingTxBatch{},
+			BatchConfirms:      []MsgConfirmBatch{},
+			LogicCalls:         []*OutgoingLogicCall{},
+			LogicCallConfirms:  []MsgConfirmLogicCall{},
+			Attestations:       []Attestation{},
+			DelegateKeys:       []*MsgSetOrchestratorAddress{},
+			Erc20ToDenoms:      []*ERC20ToDenom{},
+			UnbatchedTransfers: []*OutgoingTransferTx{},
+		}, expErr: true},
 		"invalid params": {src: &GenesisState{
 			Params: &Params{
-				GravityId:             "foo",
-				ContractSourceHash:    "laksdjflasdkfja",
-				BridgeEthereumAddress: "invalid-eth-address",
-				BridgeChainId:         3279089,
+				GravityId:                    "foo",
+				ContractSourceHash:           "laksdjflasdkfja",
+				BridgeEthereumAddress:        "invalid-eth-address",
+				BridgeChainId:                3279089,
+				SignedValsetsWindow:          0,
+				SignedBatchesWindow:          0,
+				SignedLogicCallsWindow:       0,
+				TargetBatchTimeout:           0,
+				AverageBlockTime:             0,
+				AverageEthereumBlockTime:     0,
+				SlashFractionValset:          types.Dec{},
+				SlashFractionBatch:           types.Dec{},
+				SlashFractionLogicCall:       types.Dec{},
+				UnbondSlashingValsetsWindow:  0,
+				SlashFractionBadEthSignature: types.Dec{},
+				ValsetReward: types.Coin{
+					Denom:  "",
+					Amount: types.Int{},
+				},
 			},
+			LastObservedNonce:  0,
+			Valsets:            []*Valset{},
+			ValsetConfirms:     []*MsgValsetConfirm{},
+			Batches:            []*OutgoingTxBatch{},
+			BatchConfirms:      []MsgConfirmBatch{},
+			LogicCalls:         []*OutgoingLogicCall{},
+			LogicCallConfirms:  []MsgConfirmLogicCall{},
+			Attestations:       []Attestation{},
+			DelegateKeys:       []*MsgSetOrchestratorAddress{},
+			Erc20ToDenoms:      []*ERC20ToDenom{},
+			UnbatchedTransfers: []*OutgoingTransferTx{},
 		}, expErr: true},
 	}
 	for msg, spec := range specs {

--- a/module/x/gravity/types/msgs.go
+++ b/module/x/gravity/types/msgs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tendermint/tendermint/crypto/tmhash"
 )
 
+//nolint: exhaustivestruct
 var (
 	_ sdk.Msg = &MsgSetOrchestratorAddress{}
 	_ sdk.Msg = &MsgValsetConfirm{}
@@ -176,6 +177,7 @@ func (msg MsgSendToEth) GetSigners() []sdk.AccAddress {
 func NewMsgRequestBatch(orchestrator sdk.AccAddress) *MsgRequestBatch {
 	return &MsgRequestBatch{
 		Sender: orchestrator.String(),
+		Denom:  "",
 	}
 }
 
@@ -310,6 +312,7 @@ type EthereumClaim interface {
 	ClaimHash() []byte
 }
 
+//nolint: exhaustivestruct
 var (
 	_ EthereumClaim = &MsgSendToCosmosClaim{}
 	_ EthereumClaim = &MsgBatchSendToEthClaim{}

--- a/module/x/gravity/types/types.go
+++ b/module/x/gravity/types/types.go
@@ -220,7 +220,13 @@ func (v *Valset) WithoutEmptyMembers() *Valset {
 	if v == nil {
 		return nil
 	}
-	r := Valset{Nonce: v.Nonce, Members: make([]*BridgeValidator, 0, len(v.Members))}
+	r := Valset{
+		Nonce:        v.Nonce,
+		Members:      make([]*BridgeValidator, 0, len(v.Members)),
+		Height:       0,
+		RewardAmount: sdk.Int{},
+		RewardToken:  "",
+	}
 	for i := range v.Members {
 		if err := v.Members[i].ValidateBasic(); err == nil {
 			r.Members = append(r.Members, v.Members[i])


### PR DESCRIPTION
In Golang there is no requirement to initialize all of a structs members when creating an instance of a struct. There is an "exhaustivestruct" golangci linter available but disabled by default which will lint struct usage automatically and report when a struct's members have been initialized to zero/nil/empty/falsy.