### PR TITLE
Consistent Eth Addresses - ERC20Token

### DIFF
--- a/module/x/gravity/abci_test.go
+++ b/module/x/gravity/abci_test.go
@@ -268,10 +268,10 @@ func TestBatchTimeout(t *testing.T) {
 		mySender, _         = sdk.AccAddressFromBech32("cosmos1ahx7f8wyertuus9r20284ej0asrs085case3kn")
 		myReceiver          = "0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7"
 		myTokenContractAddr = "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5" // Pickle
-		allVouchers         = sdk.NewCoins(
-			types.NewERC20Token(99999, myTokenContractAddr).GravityCoin(),
-		)
+		token, err          = types.NewInternalERC20Token(sdk.NewInt(99999), myTokenContractAddr)
+		allVouchers         = sdk.NewCoins(token.GravityCoin())
 	)
+	require.NoError(t, err)
 
 	require.Greater(t, params.AverageBlockTime, uint64(0))
 	require.Greater(t, params.AverageEthereumBlockTime, uint64(0))
@@ -284,9 +284,14 @@ func TestBatchTimeout(t *testing.T) {
 
 	// add some TX to the pool
 	for i, v := range []uint64{2, 3, 2, 1, 5, 6} {
-		amount := types.NewERC20Token(uint64(i+100), myTokenContractAddr).GravityCoin()
-		fee := types.NewERC20Token(v, myTokenContractAddr).GravityCoin()
-		_, err := input.GravityKeeper.AddToOutgoingPool(ctx, mySender, myReceiver, amount, fee)
+		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr)
+		require.NoError(t, err)
+		amount := amountToken.GravityCoin()
+		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr)
+		require.NoError(t, err)
+		fee := feeToken.GravityCoin()
+
+		_, err = input.GravityKeeper.AddToOutgoingPool(ctx, mySender, myReceiver, amount, fee)
 		require.NoError(t, err)
 	}
 

--- a/module/x/gravity/cosmos-originated_test.go
+++ b/module/x/gravity/cosmos-originated_test.go
@@ -100,11 +100,13 @@ func addDenomToERC20Relation(tv *testingVars) {
 	require.NoError(tv.t, err)
 	assert.True(tv.t, isCosmosOriginated)
 
-	isCosmosOriginated, gotDenom := tv.input.GravityKeeper.ERC20ToDenomLookup(tv.ctx, tv.erc20)
+	ethAddr, err := types.NewEthAddress(tv.erc20)
+	require.NoError(tv.t, err)
+	isCosmosOriginated, gotDenom := tv.input.GravityKeeper.ERC20ToDenomLookup(tv.ctx, *ethAddr)
 	assert.True(tv.t, isCosmosOriginated)
 
 	assert.Equal(tv.t, tv.denom, gotDenom)
-	assert.Equal(tv.t, tv.erc20, gotERC20)
+	assert.Equal(tv.t, tv.erc20, gotERC20.GetAddress())
 }
 
 func lockCoinsInModule(tv *testingVars) {

--- a/module/x/gravity/keeper/batch.go
+++ b/module/x/gravity/keeper/batch.go
@@ -160,9 +160,13 @@ func (k Keeper) pickUnbatchedTX(
 	var err error
 	k.IterateUnbatchedTransactionsByContract(ctx, contractAddress, func(_ []byte, tx *types.OutgoingTransferTx) bool {
 		if tx != nil && tx.Erc20Fee != nil {
+			feeInt, err := tx.Erc20Fee.ToInternal()
+			if err != nil {
+				panic(fmt.Errorf("invalid fee in unbatched tx: %v", err))
+			}
 			selectedTx = append(selectedTx, tx)
-			err = k.removeUnbatchedTX(ctx, *tx.Erc20Fee, tx.Id)
-			oldTx, oldTxErr := k.GetUnbatchedTxByFeeAndId(ctx, *tx.Erc20Fee, tx.Id)
+			err = k.removeUnbatchedTX(ctx, *feeInt, tx.Id)
+			oldTx, oldTxErr := k.GetUnbatchedTxByFeeAndId(ctx, *feeInt, tx.Id)
 			if oldTx != nil || oldTxErr == nil {
 				panic("picked a duplicate transaction from the pool, duplicates should never exist!")
 			}

--- a/module/x/gravity/keeper/evidence_test.go
+++ b/module/x/gravity/keeper/evidence_test.go
@@ -22,10 +22,10 @@ func TestSubmitBadSignatureEvidenceBatchExists(t *testing.T) {
 		mySender, _         = sdk.AccAddressFromBech32("cosmos1ahx7f8wyertuus9r20284ej0asrs085case3kn")
 		myReceiver          = "0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7"
 		myTokenContractAddr = "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5" // Pickle
-		allVouchers         = sdk.NewCoins(
-			types.NewERC20Token(99999, myTokenContractAddr).GravityCoin(),
-		)
+		token, err          = types.NewInternalERC20Token(sdk.NewInt(99999), myTokenContractAddr)
+		allVouchers         = sdk.NewCoins(token.GravityCoin())
 	)
+	require.NoError(t, err)
 
 	// mint some voucher first
 	require.NoError(t, input.BankKeeper.MintCoins(ctx, types.ModuleName, allVouchers))
@@ -37,9 +37,14 @@ func TestSubmitBadSignatureEvidenceBatchExists(t *testing.T) {
 
 	// add some TX to the pool
 	for i, v := range []uint64{2, 3, 2, 1} {
-		amount := types.NewERC20Token(uint64(i+100), myTokenContractAddr).GravityCoin()
-		fee := types.NewERC20Token(v, myTokenContractAddr).GravityCoin()
-		_, err := input.GravityKeeper.AddToOutgoingPool(ctx, mySender, myReceiver, amount, fee)
+		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr)
+		require.NoError(t, err)
+		amount := amountToken.GravityCoin()
+		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr)
+		require.NoError(t, err)
+		fee := feeToken.GravityCoin()
+
+		_, err = input.GravityKeeper.AddToOutgoingPool(ctx, mySender, myReceiver, amount, fee)
 		require.NoError(t, err)
 	}
 

--- a/module/x/gravity/keeper/genesis.go
+++ b/module/x/gravity/keeper/genesis.go
@@ -121,8 +121,12 @@ func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) {
 	}
 
 	// populate state with cosmos originated denom-erc20 mapping
-	for _, item := range data.Erc20ToDenoms {
-		k.setCosmosOriginatedDenomToERC20(ctx, item.Denom, item.Erc20)
+	for i, item := range data.Erc20ToDenoms {
+		ethAddr, err := types.NewEthAddress(item.Erc20)
+		if err != nil {
+			panic(fmt.Errorf("invalid erc20 address in Erc20ToDenoms for item %d: %s", i, item.Erc20))
+		}
+		k.setCosmosOriginatedDenomToERC20(ctx, item.Denom, *ethAddr)
 	}
 
 	// now that we have the denom-erc20 mapping we need to validate

--- a/module/x/gravity/keeper/grpc_query.go
+++ b/module/x/gravity/keeper/grpc_query.go
@@ -253,7 +253,7 @@ func (k Keeper) DenomToERC20(
 	ctx := sdk.UnwrapSDKContext(c)
 	cosmosOriginated, erc20, err := k.DenomToERC20Lookup(ctx, req.Denom)
 	var ret types.QueryDenomToERC20Response
-	ret.Erc20 = erc20
+	ret.Erc20 = erc20.GetAddress()
 	ret.CosmosOriginated = cosmosOriginated
 
 	return &ret, err
@@ -264,7 +264,11 @@ func (k Keeper) ERC20ToDenom(
 	c context.Context,
 	req *types.QueryERC20ToDenomRequest) (*types.QueryERC20ToDenomResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
-	cosmosOriginated, name := k.ERC20ToDenomLookup(ctx, req.Erc20)
+	ethAddr, err := types.NewEthAddress(req.Erc20)
+	if err != nil {
+		return nil, sdkerrors.Wrapf(err, "invalid Erc20 in request: %s", req.Erc20)
+	}
+	cosmosOriginated, name := k.ERC20ToDenomLookup(ctx, *ethAddr)
 	var ret types.QueryERC20ToDenomResponse
 	ret.Denom = name
 	ret.CosmosOriginated = cosmosOriginated

--- a/module/x/gravity/keeper/keeper_valset.go
+++ b/module/x/gravity/keeper/keeper_valset.go
@@ -258,13 +258,13 @@ func (k Keeper) GetCurrentValset(ctx sdk.Context) *types.Valset {
 
 	// get the reward from the params store
 	reward := k.GetParams(ctx).ValsetReward
-	var rewardToken string
+	var rewardToken *types.EthAddress
 	var rewardAmount sdk.Int
 	if !reward.IsValid() || reward.IsZero() {
 		// the case where a validator has 'no reward'. The 'no reward' value is interpreted as having a zero
 		// address for the ERC20 token and a zero value for the reward amount. Since we store a coin with the
 		// params, a coin with a blank denom and/or zero amount is interpreted in this way.
-		rewardToken = "0x0000000000000000000000000000000000000000"
+		rewardToken = types.ZeroAddress()
 		rewardAmount = sdk.NewIntFromUint64(0)
 
 	} else {
@@ -274,7 +274,7 @@ func (k Keeper) GetCurrentValset(ctx sdk.Context) *types.Valset {
 	// increment the nonce, since this potential future valset should be after the current valset
 	valsetNonce := k.GetLatestValsetNonce(ctx) + 1
 
-	valset, err := types.NewValset(valsetNonce, uint64(ctx.BlockHeight()), bridgeValidators, rewardAmount, rewardToken)
+	valset, err := types.NewValset(valsetNonce, uint64(ctx.BlockHeight()), bridgeValidators, rewardAmount, rewardToken.GetAddress())
 	if err != nil {
 		panic(sdkerrors.Wrap(err, "generated invalid valset"))
 	}

--- a/module/x/gravity/keeper/msg_server.go
+++ b/module/x/gravity/keeper/msg_server.go
@@ -141,7 +141,7 @@ func (k msgServer) RequestBatch(c context.Context, msg *types.MsgRequestBatch) (
 		return nil, err
 	}
 
-	batch, err := k.BuildOutgoingTXBatch(ctx, tokenContract, OutgoingTxBatchSize)
+	batch, err := k.BuildOutgoingTXBatch(ctx, tokenContract.GetAddress(), OutgoingTxBatchSize)
 	if err != nil {
 		return nil, err
 	}

--- a/module/x/gravity/keeper/querier.go
+++ b/module/x/gravity/keeper/querier.go
@@ -495,7 +495,7 @@ func queryDenomToERC20(ctx sdk.Context, denom string, keeper Keeper) ([]byte, er
 	}
 	var response types.QueryDenomToERC20Response
 	response.CosmosOriginated = cosmos_originated
-	response.Erc20 = erc20
+	response.Erc20 = erc20.GetAddress()
 	bytes, err := codec.MarshalJSONIndent(types.ModuleCdc, response)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
@@ -505,7 +505,11 @@ func queryDenomToERC20(ctx sdk.Context, denom string, keeper Keeper) ([]byte, er
 }
 
 func queryERC20ToDenom(ctx sdk.Context, ERC20 string, keeper Keeper) ([]byte, error) {
-	cosmos_originated, denom := keeper.ERC20ToDenomLookup(ctx, ERC20)
+	ethAddr, err := types.NewEthAddress(ERC20)
+	if err != nil {
+		return nil, sdkerrors.Wrapf(err, "invalid ERC20 in query: %s", ERC20)
+	}
+	cosmos_originated, denom := keeper.ERC20ToDenomLookup(ctx, *ethAddr)
 	var response types.QueryERC20ToDenomResponse
 	response.CosmosOriginated = cosmos_originated
 	response.Denom = denom

--- a/module/x/gravity/keeper/test_common.go
+++ b/module/x/gravity/keeper/test_common.go
@@ -492,7 +492,7 @@ func MakeTestMarshaler() codec.Marshaler {
 }
 
 // MintVouchersFromAir creates new gravity vouchers given erc20tokens
-func MintVouchersFromAir(t *testing.T, ctx sdk.Context, k Keeper, dest sdk.AccAddress, amount types.ERC20Token) sdk.Coin {
+func MintVouchersFromAir(t *testing.T, ctx sdk.Context, k Keeper, dest sdk.AccAddress, amount types.InternalERC20Token) sdk.Coin {
 	coin := amount.GravityCoin()
 	vouchers := sdk.Coins{coin}
 	err := k.bankKeeper.MintCoins(ctx, types.ModuleName, vouchers)

--- a/module/x/gravity/types/errors.go
+++ b/module/x/gravity/types/errors.go
@@ -15,4 +15,5 @@ var (
 	ErrUnsupported             = sdkerrors.Register(ModuleName, 8, "unsupported")
 	ErrNonContiguousEventNonce = sdkerrors.Register(ModuleName, 9, "non contiguous event nonce")
 	ErrResetDelegateKeys       = sdkerrors.Register(ModuleName, 10, "can not set orchestrator addresses more than once")
+	ErrMismatched              = sdkerrors.Register(ModuleName, 11, "mismatched")
 )

--- a/module/x/gravity/types/key.go
+++ b/module/x/gravity/types/key.go
@@ -217,14 +217,14 @@ func GetOutgoingTxPoolContractPrefix(contractAddress string) []byte {
 // GetOutgoingTxPoolKey returns the following key format
 // prefix	feeContract		feeAmount     id
 // [0x6][0xc783df8a850f42e7F7e57013759C285caa701eB6][1000000000][0 0 0 0 0 0 0 1]
-func GetOutgoingTxPoolKey(fee ERC20Token, id uint64) []byte {
+func GetOutgoingTxPoolKey(fee InternalERC20Token, id uint64) []byte {
 	// sdkInts have a size limit of 255 bits or 32 bytes
 	// therefore this will never panic and is always safe
 	amount := make([]byte, 32)
 	amount = fee.Amount.BigInt().FillBytes(amount)
 
 	a := append(amount, UInt64Bytes(id)...)
-	b := append([]byte(fee.Contract), a...)
+	b := append([]byte(fee.Contract.GetAddress()), a...)
 	r := append(OutgoingTXPoolKey, b...)
 	return r
 }


### PR DESCRIPTION
ERC20Token now must be converted to the InternalERC20Token type, which has a validated EthAddress member instead of a string. All functions accepting ERC20Token parameters have been converted to use InternalERC20Token parameters instead.