### PR TITLE
Consistent Eth Addresses - OutgoingTransferTx

### DIFF
--- a/module/x/gravity/keeper/batch_test.go
+++ b/module/x/gravity/keeper/batch_test.go
@@ -18,12 +18,12 @@ func TestBatches(t *testing.T) {
 	input := CreateTestEnv(t)
 	ctx := input.Context
 	var (
-		now                 = time.Now().UTC()
-		mySender, _         = sdk.AccAddressFromBech32("cosmos1ahx7f8wyertuus9r20284ej0asrs085case3kn")
-		myReceiver          = "0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7"
-		myTokenContractAddr = "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5" // Pickle
-		token, err          = types.NewInternalERC20Token(sdk.NewInt(99999), myTokenContractAddr)
-		allVouchers         = sdk.NewCoins(token.GravityCoin())
+		now                    = time.Now().UTC()
+		mySender, _            = sdk.AccAddressFromBech32("cosmos1ahx7f8wyertuus9r20284ej0asrs085case3kn")
+		myReceiver, _          = types.NewEthAddress("0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7")
+		myTokenContractAddr, _ = types.NewEthAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5") // Pickle
+		token, err             = types.NewInternalERC20Token(sdk.NewInt(99999), myTokenContractAddr.GetAddress())
+		allVouchers            = sdk.NewCoins(token.GravityCoin())
 	)
 	require.NoError(t, err)
 
@@ -38,14 +38,14 @@ func TestBatches(t *testing.T) {
 
 	// add some TX to the pool
 	for i, v := range []uint64{2, 3, 2, 1} {
-		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr)
+		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr.GetAddress())
 		require.NoError(t, err)
 		amount := amountToken.GravityCoin()
-		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr)
+		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr.GetAddress())
 		require.NoError(t, err)
 		fee := feeToken.GravityCoin()
 
-		_, err = input.GravityKeeper.AddToOutgoingPool(ctx, mySender, myReceiver, amount, fee)
+		_, err = input.GravityKeeper.AddToOutgoingPool(ctx, mySender, myReceiver.GetAddress(), amount, fee)
 		require.NoError(t, err)
 		ctx.Logger().Info(fmt.Sprintf("Created transaction %v with amount %v and fee %v", i, amount, fee))
 		// Should create:
@@ -59,7 +59,7 @@ func TestBatches(t *testing.T) {
 	ctx = ctx.WithBlockTime(now)
 
 	// tx batch size is 2, so that some of them stay behind
-	firstBatch, err := input.GravityKeeper.BuildOutgoingTXBatch(ctx, myTokenContractAddr, 2)
+	firstBatch, err := input.GravityKeeper.BuildOutgoingTXBatch(ctx, myTokenContractAddr.GetAddress(), 2)
 	require.NoError(t, err)
 
 	// then batch is persisted
@@ -73,41 +73,45 @@ func TestBatches(t *testing.T) {
 		Transactions: []*types.OutgoingTransferTx{
 			{
 				Id:          2,
-				Erc20Fee:    types.NewERC20Token(3, myTokenContractAddr),
+				Erc20Fee:    types.NewERC20Token(3, myTokenContractAddr.GetAddress()),
 				Sender:      mySender.String(),
-				DestAddress: myReceiver,
-				Erc20Token:  types.NewERC20Token(101, myTokenContractAddr),
+				DestAddress: myReceiver.GetAddress(),
+				Erc20Token:  types.NewERC20Token(101, myTokenContractAddr.GetAddress()),
 			},
 			{
 				Id:          3,
-				Erc20Fee:    types.NewERC20Token(2, myTokenContractAddr),
+				Erc20Fee:    types.NewERC20Token(2, myTokenContractAddr.GetAddress()),
 				Sender:      mySender.String(),
-				DestAddress: myReceiver,
-				Erc20Token:  types.NewERC20Token(102, myTokenContractAddr),
+				DestAddress: myReceiver.GetAddress(),
+				Erc20Token:  types.NewERC20Token(102, myTokenContractAddr.GetAddress()),
 			},
 		},
-		TokenContract: myTokenContractAddr,
+		TokenContract: myTokenContractAddr.GetAddress(),
 		Block:         1234567,
 	}
 	assert.Equal(t, expFirstBatch, gotFirstBatch)
 
 	// and verify remaining available Tx in the pool
 	// Should still have 1: and 4: above
-	gotUnbatchedTx := input.GravityKeeper.GetUnbatchedTransactionsByContract(ctx, myTokenContractAddr)
-	expUnbatchedTx := []*types.OutgoingTransferTx{
+	gotUnbatchedTx := input.GravityKeeper.GetUnbatchedTransactionsByContract(ctx, myTokenContractAddr.GetAddress())
+	oneFee, _ := types.NewInternalERC20Token(sdk.NewInt(1), myTokenContractAddr.GetAddress())
+	oneHundredTok, _ := types.NewInternalERC20Token(sdk.NewInt(100), myTokenContractAddr.GetAddress())
+	twoFee, _ := types.NewInternalERC20Token(sdk.NewInt(2), myTokenContractAddr.GetAddress())
+	oneHundredThreeTok, _ := types.NewInternalERC20Token(sdk.NewInt(103), myTokenContractAddr.GetAddress())
+	expUnbatchedTx := []*types.InternalOutgoingTransferTx{
 		{
 			Id:          1,
-			Erc20Fee:    types.NewERC20Token(2, myTokenContractAddr),
+			Erc20Fee:    twoFee,
 			Sender:      mySender.String(),
 			DestAddress: myReceiver,
-			Erc20Token:  types.NewERC20Token(100, myTokenContractAddr),
+			Erc20Token:  oneHundredTok,
 		},
 		{
 			Id:          4,
-			Erc20Fee:    types.NewERC20Token(1, myTokenContractAddr),
+			Erc20Fee:    oneFee,
 			Sender:      mySender.String(),
 			DestAddress: myReceiver,
-			Erc20Token:  types.NewERC20Token(103, myTokenContractAddr),
+			Erc20Token:  oneHundredThreeTok,
 		},
 	}
 	assert.Equal(t, expUnbatchedTx, gotUnbatchedTx)
@@ -117,14 +121,14 @@ func TestBatches(t *testing.T) {
 
 	// add some more TX to the pool to create a more profitable batch
 	for i, v := range []uint64{4, 5} {
-		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr)
+		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr.GetAddress())
 		require.NoError(t, err)
 		amount := amountToken.GravityCoin()
-		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr)
+		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr.GetAddress())
 		require.NoError(t, err)
 		fee := feeToken.GravityCoin()
 
-		_, err = input.GravityKeeper.AddToOutgoingPool(ctx, mySender, myReceiver, amount, fee)
+		_, err = input.GravityKeeper.AddToOutgoingPool(ctx, mySender, myReceiver.GetAddress(), amount, fee)
 		require.NoError(t, err)
 		// Creates the following:
 		// 5: amount 100, fee 4, id 5
@@ -134,7 +138,7 @@ func TestBatches(t *testing.T) {
 	// create the more profitable batch
 	ctx = ctx.WithBlockTime(now)
 	// tx batch size is 2, so that some of them stay behind
-	secondBatch, err := input.GravityKeeper.BuildOutgoingTXBatch(ctx, myTokenContractAddr, 2)
+	secondBatch, err := input.GravityKeeper.BuildOutgoingTXBatch(ctx, myTokenContractAddr.GetAddress(), 2)
 	require.NoError(t, err)
 
 	// check that the more profitable batch has the right txs in it
@@ -144,20 +148,20 @@ func TestBatches(t *testing.T) {
 		Transactions: []*types.OutgoingTransferTx{
 			{
 				Id:          6,
-				Erc20Fee:    types.NewERC20Token(5, myTokenContractAddr),
+				Erc20Fee:    types.NewERC20Token(5, myTokenContractAddr.GetAddress()),
 				Sender:      mySender.String(),
-				DestAddress: myReceiver,
-				Erc20Token:  types.NewERC20Token(101, myTokenContractAddr),
+				DestAddress: myReceiver.GetAddress(),
+				Erc20Token:  types.NewERC20Token(101, myTokenContractAddr.GetAddress()),
 			},
 			{
 				Id:          5,
-				Erc20Fee:    types.NewERC20Token(4, myTokenContractAddr),
+				Erc20Fee:    types.NewERC20Token(4, myTokenContractAddr.GetAddress()),
 				Sender:      mySender.String(),
-				DestAddress: myReceiver,
-				Erc20Token:  types.NewERC20Token(100, myTokenContractAddr),
+				DestAddress: myReceiver.GetAddress(),
+				Erc20Token:  types.NewERC20Token(100, myTokenContractAddr.GetAddress()),
 			},
 		},
-		TokenContract: myTokenContractAddr,
+		TokenContract: myTokenContractAddr.GetAddress(),
 		Block:         1234567,
 	}
 
@@ -174,35 +178,38 @@ func TestBatches(t *testing.T) {
 	require.Nil(t, gotSecondBatch)
 
 	// check that txs from first batch have been freed
-	gotUnbatchedTx = input.GravityKeeper.GetUnbatchedTransactionsByContract(ctx, myTokenContractAddr)
-	expUnbatchedTx = []*types.OutgoingTransferTx{
+	gotUnbatchedTx = input.GravityKeeper.GetUnbatchedTransactionsByContract(ctx, myTokenContractAddr.GetAddress())
+	threeFee, _ := types.NewInternalERC20Token(sdk.NewInt(3), myTokenContractAddr.GetAddress())
+	oneHundredOneTok, _ := types.NewInternalERC20Token(sdk.NewInt(101), myTokenContractAddr.GetAddress())
+	oneHundredTwoTok, _ := types.NewInternalERC20Token(sdk.NewInt(102), myTokenContractAddr.GetAddress())
+	expUnbatchedTx = []*types.InternalOutgoingTransferTx{
 		{
 			Id:          2,
-			Erc20Fee:    types.NewERC20Token(3, myTokenContractAddr),
+			Erc20Fee:    threeFee,
 			Sender:      mySender.String(),
 			DestAddress: myReceiver,
-			Erc20Token:  types.NewERC20Token(101, myTokenContractAddr),
+			Erc20Token:  oneHundredOneTok,
 		},
 		{
 			Id:          3,
-			Erc20Fee:    types.NewERC20Token(2, myTokenContractAddr),
+			Erc20Fee:    twoFee,
 			Sender:      mySender.String(),
 			DestAddress: myReceiver,
-			Erc20Token:  types.NewERC20Token(102, myTokenContractAddr),
+			Erc20Token:  oneHundredTwoTok,
 		},
 		{
 			Id:          1,
-			Erc20Fee:    types.NewERC20Token(2, myTokenContractAddr),
+			Erc20Fee:    twoFee,
 			Sender:      mySender.String(),
 			DestAddress: myReceiver,
-			Erc20Token:  types.NewERC20Token(100, myTokenContractAddr),
+			Erc20Token:  oneHundredTok,
 		},
 		{
 			Id:          4,
-			Erc20Fee:    types.NewERC20Token(1, myTokenContractAddr),
+			Erc20Fee:    oneFee,
 			Sender:      mySender.String(),
 			DestAddress: myReceiver,
-			Erc20Token:  types.NewERC20Token(103, myTokenContractAddr),
+			Erc20Token:  oneHundredThreeTok,
 		},
 	}
 	assert.Equal(t, expUnbatchedTx, gotUnbatchedTx)
@@ -218,6 +225,7 @@ func TestBatchesFullCoins(t *testing.T) {
 		now                 = time.Now().UTC()
 		mySender, _         = sdk.AccAddressFromBech32("cosmos1ahx7f8wyertuus9r20284ej0asrs085case3kn")
 		myReceiver          = "0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7"
+		receiverAddr, _     = types.NewEthAddress(myReceiver)
 		myTokenContractAddr = "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5"   // Pickle
 		totalCoins, _       = sdk.NewIntFromString("1500000000000000000000") // 1,500 ETH worth
 		oneEth, _           = sdk.NewIntFromString("1000000000000000000")
@@ -285,20 +293,22 @@ func TestBatchesFullCoins(t *testing.T) {
 
 	// and verify remaining available Tx in the pool
 	gotUnbatchedTx := input.GravityKeeper.GetUnbatchedTransactionsByContract(ctx, myTokenContractAddr)
-	expUnbatchedTx := []*types.OutgoingTransferTx{
+	twentyTok, _ := types.NewInternalERC20Token(oneEth.Mul(sdk.NewIntFromUint64(20)), myTokenContractAddr)
+	tenTok, _ := types.NewInternalERC20Token(oneEth.Mul(sdk.NewIntFromUint64(10)), myTokenContractAddr)
+	expUnbatchedTx := []*types.InternalOutgoingTransferTx{
 		{
 			Id:          1,
-			Erc20Fee:    types.NewSDKIntERC20Token(oneEth.Mul(sdk.NewIntFromUint64(20)), myTokenContractAddr),
+			Erc20Fee:    twentyTok,
 			Sender:      mySender.String(),
-			DestAddress: myReceiver,
-			Erc20Token:  types.NewSDKIntERC20Token(oneEth.Mul(sdk.NewIntFromUint64(20)), myTokenContractAddr),
+			DestAddress: receiverAddr,
+			Erc20Token:  twentyTok,
 		},
 		{
 			Id:          4,
-			Erc20Fee:    types.NewSDKIntERC20Token(oneEth.Mul(sdk.NewIntFromUint64(10)), myTokenContractAddr),
+			Erc20Fee:    tenTok,
 			Sender:      mySender.String(),
-			DestAddress: myReceiver,
-			Erc20Token:  types.NewSDKIntERC20Token(oneEth.Mul(sdk.NewIntFromUint64(10)), myTokenContractAddr),
+			DestAddress: receiverAddr,
+			Erc20Token:  tenTok,
 		},
 	}
 	assert.Equal(t, expUnbatchedTx, gotUnbatchedTx)
@@ -363,34 +373,38 @@ func TestBatchesFullCoins(t *testing.T) {
 
 	// check that txs from first batch have been freed
 	gotUnbatchedTx = input.GravityKeeper.GetUnbatchedTransactionsByContract(ctx, myTokenContractAddr)
-	expUnbatchedTx = []*types.OutgoingTransferTx{
+	threeHundredTok, _ := types.NewInternalERC20Token(oneEth.Mul(sdk.NewIntFromUint64(300)), myTokenContractAddr)
+	twentyFiveTok, _ := types.NewInternalERC20Token(oneEth.Mul(sdk.NewIntFromUint64(25)), myTokenContractAddr)
+	fiveTok, _ := types.NewInternalERC20Token(oneEth.Mul(sdk.NewIntFromUint64(5)), myTokenContractAddr)
+	fourTok, _ := types.NewInternalERC20Token(oneEth.Mul(sdk.NewIntFromUint64(4)), myTokenContractAddr)
+	expUnbatchedTx = []*types.InternalOutgoingTransferTx{
 		{
 			Id:          2,
-			Erc20Fee:    types.NewSDKIntERC20Token(oneEth.Mul(sdk.NewIntFromUint64(300)), myTokenContractAddr),
+			Erc20Fee:    threeHundredTok,
 			Sender:      mySender.String(),
-			DestAddress: myReceiver,
-			Erc20Token:  types.NewSDKIntERC20Token(oneEth.Mul(sdk.NewIntFromUint64(300)), myTokenContractAddr),
+			DestAddress: receiverAddr,
+			Erc20Token:  threeHundredTok,
 		},
 		{
 			Id:          3,
-			Erc20Fee:    types.NewSDKIntERC20Token(oneEth.Mul(sdk.NewIntFromUint64(25)), myTokenContractAddr),
+			Erc20Fee:    twentyFiveTok,
 			Sender:      mySender.String(),
-			DestAddress: myReceiver,
-			Erc20Token:  types.NewSDKIntERC20Token(oneEth.Mul(sdk.NewIntFromUint64(25)), myTokenContractAddr),
+			DestAddress: receiverAddr,
+			Erc20Token:  twentyFiveTok,
 		},
 		{
 			Id:          6,
-			Erc20Fee:    types.NewSDKIntERC20Token(oneEth.Mul(sdk.NewIntFromUint64(5)), myTokenContractAddr),
+			Erc20Fee:    fiveTok,
 			Sender:      mySender.String(),
-			DestAddress: myReceiver,
-			Erc20Token:  types.NewSDKIntERC20Token(oneEth.Mul(sdk.NewIntFromUint64(5)), myTokenContractAddr),
+			DestAddress: receiverAddr,
+			Erc20Token:  fiveTok,
 		},
 		{
 			Id:          5,
-			Erc20Fee:    types.NewSDKIntERC20Token(oneEth.Mul(sdk.NewIntFromUint64(4)), myTokenContractAddr),
+			Erc20Fee:    fourTok,
 			Sender:      mySender.String(),
-			DestAddress: myReceiver,
-			Erc20Token:  types.NewSDKIntERC20Token(oneEth.Mul(sdk.NewIntFromUint64(4)), myTokenContractAddr),
+			DestAddress: receiverAddr,
+			Erc20Token:  fourTok,
 		},
 	}
 	assert.Equal(t, expUnbatchedTx, gotUnbatchedTx)

--- a/module/x/gravity/keeper/grpc_query.go
+++ b/module/x/gravity/keeper/grpc_query.go
@@ -376,7 +376,7 @@ func (k Keeper) GetPendingSendToEth(
 	}
 	for _, tx := range unbatched_tx {
 		if tx.Sender == sender_address {
-			res.UnbatchedTransfers = append(res.UnbatchedTransfers, tx)
+			res.UnbatchedTransfers = append(res.UnbatchedTransfers, tx.ToExternal())
 		}
 	}
 

--- a/module/x/gravity/keeper/querier.go
+++ b/module/x/gravity/keeper/querier.go
@@ -538,7 +538,7 @@ func queryPendingSendToEth(ctx sdk.Context, senderAddr string, k Keeper) ([]byte
 	}
 	for _, tx := range unbatched_tx {
 		if tx.Sender == sender_address {
-			res.UnbatchedTransfers = append(res.UnbatchedTransfers, tx)
+			res.UnbatchedTransfers = append(res.UnbatchedTransfers, tx.ToExternal())
 		}
 	}
 	bytes, err := codec.MarshalJSONIndent(types.ModuleCdc, res)


### PR DESCRIPTION
OutgoingTransferTx now must be converted to the InternalOutgoingTransferTx
type, which has a validated EthAddress member for destination,
InternalERC20Tokens for fee and amount