### PR TITLE
Do not exit the relayer on GravityID failure

### DIFF
--- a/orchestrator/relayer/src/main_loop.rs
+++ b/orchestrator/relayer/src/main_loop.rs
@@ -40,7 +40,7 @@ pub async fn relayer_main_loop(
             get_gravity_id(gravity_contract_address, our_ethereum_address, &web3).await;
         if gravity_id.is_err() {
             error!("Failed to get GravityID, check your Eth node");
-            return;
+            continue;
         }
         let gravity_id = gravity_id.unwrap();
 


### PR DESCRIPTION
Becuase we used 'return' instead of 'continue' here the orchestrator would unexpectedly stop if at any time during it's loops it encountered a bad response form the Ethereum node.

Since the relayer is supposed to run indefinately this is a pretty major problem. Thanks to StoykovK on the Althea discord for reporting!