### PR TITLE
keys parse

### DIFF
--- a/module/cmd/gravity/cmd/root.go
+++ b/module/cmd/gravity/cmd/root.go
@@ -91,6 +91,9 @@ func Execute(rootCmd *cobra.Command) error {
 func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	authclient.Codec = encodingConfig.Marshaler
 
+	cfg := sdk.GetConfig()
+	cfg.Seal()
+
 	rootCmd.AddCommand(
 		genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),


### PR DESCRIPTION
same issue was present in gaia where the keys parse command was hanging. This fixes it.

However after fixing and running it I realize that the gravity bridge is still using `cosmos` prefixes in the account names. Is there another branch I should be using that is updates with the gravity prefix?